### PR TITLE
feat: add read-only issue sharing via token

### DIFF
--- a/apps/api/drizzle/0012_add_share_token.sql
+++ b/apps/api/drizzle/0012_add_share_token.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `issues` ADD `share_token` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `issues_share_token_uniq` ON `issues` (`share_token`);

--- a/apps/api/drizzle/meta/0012_snapshot.json
+++ b/apps/api/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1116 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "698bde5d-8fef-4793-a7f6-53af370a964c",
+  "prevId": "2b64e62e-cff0-4803-b062-3a54e30791a9",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "attachments_issue_id_idx": {
+          "name": "attachments_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "attachments_log_id_idx": {
+          "name": "attachments_log_id_idx",
+          "columns": [
+            "log_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "attachments_issue_id_issues_id_fk": {
+          "name": "attachments_issue_id_issues_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attachments_log_id_issues_logs_id_fk": {
+          "name": "attachments_log_id_issues_logs_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "issues_logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "issues_logs": {
+      "name": "issues_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_index": {
+          "name": "turn_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_index": {
+          "name": "entry_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_ref_id": {
+          "name": "tool_call_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_logs_issue_id_idx": {
+          "name": "issues_logs_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_issue_id_turn_entry_idx": {
+          "name": "issues_logs_issue_id_turn_entry_idx",
+          "columns": [
+            "issue_id",
+            "turn_index",
+            "entry_index"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_issue_id_visible_type_idx": {
+          "name": "issues_logs_issue_id_visible_type_idx",
+          "columns": [
+            "issue_id",
+            "visible",
+            "entry_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "issues_logs_issue_id_issues_id_fk": {
+          "name": "issues_logs_issue_id_issues_id_fk",
+          "tableFrom": "issues_logs",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "issues": {
+      "name": "issues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'a0'"
+        },
+        "parent_issue_id": {
+          "name": "parent_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_worktree": {
+          "name": "use_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "engine_type": {
+          "name": "engine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_status": {
+          "name": "session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_input_tokens": {
+          "name": "total_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_output_tokens": {
+          "name": "total_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_project_id_idx": {
+          "name": "issues_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "issues_status_id_idx": {
+          "name": "issues_status_id_idx",
+          "columns": [
+            "status_id"
+          ],
+          "isUnique": false
+        },
+        "issues_parent_issue_id_idx": {
+          "name": "issues_parent_issue_id_idx",
+          "columns": [
+            "parent_issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_project_id_status_updated_at_idx": {
+          "name": "issues_project_id_status_updated_at_idx",
+          "columns": [
+            "project_id",
+            "status_updated_at"
+          ],
+          "isUnique": false
+        },
+        "issues_project_id_issue_number_uniq": {
+          "name": "issues_project_id_issue_number_uniq",
+          "columns": [
+            "project_id",
+            "issue_number"
+          ],
+          "isUnique": true
+        },
+        "issues_share_token_uniq": {
+          "name": "issues_share_token_uniq",
+          "columns": [
+            "share_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_parent_issue_id_issues_id_fk": {
+          "name": "issues_parent_issue_id_issues_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "parent_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "issues_status_id_check": {
+          "name": "issues_status_id_check",
+          "value": "\"issues\".\"status_id\" IN ('todo','working','review','done')"
+        }
+      }
+    },
+    "issues_logs_tools_call": {
+      "name": "issues_logs_tools_call",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_result": {
+          "name": "is_result",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_logs_tools_call_log_id_idx": {
+          "name": "issues_logs_tools_call_log_id_idx",
+          "columns": [
+            "log_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_issue_id_idx": {
+          "name": "issues_logs_tools_call_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_kind_idx": {
+          "name": "issues_logs_tools_call_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_tool_name_idx": {
+          "name": "issues_logs_tools_call_tool_name_idx",
+          "columns": [
+            "tool_name"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_issue_id_kind_idx": {
+          "name": "issues_logs_tools_call_issue_id_kind_idx",
+          "columns": [
+            "issue_id",
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "issues_logs_tools_call_log_id_issues_logs_id_fk": {
+          "name": "issues_logs_tools_call_log_id_issues_logs_id_fk",
+          "tableFrom": "issues_logs_tools_call",
+          "tableTo": "issues_logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_logs_tools_call_issue_id_issues_id_fk": {
+          "name": "issues_logs_tools_call_issue_id_issues_id_fk",
+          "tableFrom": "issues_logs_tools_call",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "directory": {
+          "name": "directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'a0'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "projects_alias_unique": {
+          "name": "projects_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_webhook_id_idx": {
+          "name": "webhook_deliveries_webhook_id_idx",
+          "columns": [
+            "webhook_id"
+          ],
+          "isUnique": false
+        },
+        "webhook_deliveries_created_at_idx": {
+          "name": "webhook_deliveries_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "webhook_deliveries_dedup_idx": {
+          "name": "webhook_deliveries_dedup_idx",
+          "columns": [
+            "webhook_id",
+            "dedup_key",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1773273600001,
       "tag": "0011_sleepy_captain_marvel",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1773849600000,
+      "tag": "0012_add_share_token",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -63,6 +63,7 @@ export const issues = sqliteTable(
     externalSessionId: text('external_session_id'),
 
     model: text('model'),
+    shareToken: text('share_token'),
     totalInputTokens: integer('total_input_tokens').notNull().default(0),
     totalOutputTokens: integer('total_output_tokens').notNull().default(0),
     totalCostUsd: text('total_cost_usd').notNull().default('0'),
@@ -79,6 +80,7 @@ export const issues = sqliteTable(
     index('issues_project_id_status_updated_at_idx').on(table.projectId, table.statusUpdatedAt),
     check('issues_status_id_check', sql`${table.statusId} IN ('todo','working','review','done')`),
     uniqueIndex('issues_project_id_issue_number_uniq').on(table.projectId, table.issueNumber),
+    uniqueIndex('issues_share_token_uniq').on(table.shareToken),
   ],
 )
 

--- a/apps/api/src/routes/api.ts
+++ b/apps/api/src/routes/api.ts
@@ -8,6 +8,7 @@ import issues from './issues'
 import reviewIssues from './issues/review'
 import processes from './processes'
 import projects from './projects'
+import shareRoutes from './share'
 import worktrees from './worktrees'
 
 const apiRoutes = new Hono()
@@ -16,6 +17,7 @@ const apiRoutes = new Hono()
 apiRoutes.route('/projects', projects)
 apiRoutes.route('/projects/:projectId/issues', issues)
 apiRoutes.route('/issues/review', reviewIssues)
+apiRoutes.route('/share', shareRoutes)
 apiRoutes.route('/files', files)
 apiRoutes.route('/projects/:projectId/processes', processes)
 apiRoutes.route('/projects/:projectId/worktrees', worktrees)

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -95,6 +95,7 @@ export function serializeIssue(row: IssueRow, childCount?: number) {
     prompt: row.prompt ?? null,
     externalSessionId: row.externalSessionId ?? null,
     model: row.model ?? null,
+    shareToken: row.shareToken ?? null,
     statusUpdatedAt: toISO(row.statusUpdatedAt),
     createdAt: toISO(row.createdAt),
     updatedAt: toISO(row.updatedAt),

--- a/apps/api/src/routes/issues/index.ts
+++ b/apps/api/src/routes/issues/index.ts
@@ -7,6 +7,7 @@ import del from './delete'
 import logs from './logs'
 import message from './message'
 import query from './query'
+import share from './share'
 import title from './title'
 import update from './update'
 
@@ -21,5 +22,6 @@ issues.route('/', message)
 issues.route('/', attachments)
 issues.route('/', logs)
 issues.route('/', changes)
+issues.route('/', share)
 
 export default issues

--- a/apps/api/src/routes/issues/share.ts
+++ b/apps/api/src/routes/issues/share.ts
@@ -1,0 +1,72 @@
+import { eq } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { customAlphabet } from 'nanoid'
+import { db } from '@/db'
+import { findProject } from '@/db/helpers'
+import { issues as issuesTable } from '@/db/schema'
+import { getProjectOwnedIssue, invalidateIssueCache } from './_shared'
+
+const shareToken = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 12)
+
+const share = new Hono()
+
+// POST /api/projects/:projectId/issues/:id/share — Generate or return existing share token
+share.post('/:id/share', async (c) => {
+  const projectId = c.req.param('projectId')!
+  const project = await findProject(projectId)
+  if (!project) {
+    return c.json({ success: false, error: 'Project not found' }, 404)
+  }
+
+  const issueId = c.req.param('id')!
+  const issue = await getProjectOwnedIssue(project.id, issueId)
+  if (!issue) {
+    return c.json({ success: false, error: 'Issue not found' }, 404)
+  }
+
+  // Return existing token if already shared
+  if (issue.shareToken) {
+    return c.json({
+      success: true,
+      data: { shareToken: issue.shareToken },
+    })
+  }
+
+  // Generate new token
+  const token = shareToken()
+  await db
+    .update(issuesTable)
+    .set({ shareToken: token })
+    .where(eq(issuesTable.id, issueId))
+  await invalidateIssueCache(project.id, issueId)
+
+  return c.json({
+    success: true,
+    data: { shareToken: token },
+  })
+})
+
+// DELETE /api/projects/:projectId/issues/:id/share — Remove share token
+share.delete('/:id/share', async (c) => {
+  const projectId = c.req.param('projectId')!
+  const project = await findProject(projectId)
+  if (!project) {
+    return c.json({ success: false, error: 'Project not found' }, 404)
+  }
+
+  const issueId = c.req.param('id')!
+  const issue = await getProjectOwnedIssue(project.id, issueId)
+  if (!issue) {
+    return c.json({ success: false, error: 'Issue not found' }, 404)
+  }
+
+  await db
+    .update(issuesTable)
+    .set({ shareToken: null })
+    .where(eq(issuesTable.id, issueId))
+  await invalidateIssueCache(project.id, issueId)
+
+  return c.json({ success: true, data: null })
+})
+
+export default share

--- a/apps/api/src/routes/issues/share.ts
+++ b/apps/api/src/routes/issues/share.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { customAlphabet } from 'nanoid'
 import { db } from '@/db'
@@ -6,7 +6,7 @@ import { findProject } from '@/db/helpers'
 import { issues as issuesTable } from '@/db/schema'
 import { getProjectOwnedIssue, invalidateIssueCache } from './_shared'
 
-const shareToken = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 12)
+const generateShareToken = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 12)
 
 const share = new Hono()
 
@@ -32,12 +32,23 @@ share.post('/:id/share', async (c) => {
     })
   }
 
-  // Generate new token
-  const token = shareToken()
-  await db
+  // Atomically set token only when currently null to handle concurrent requests
+  const token = generateShareToken()
+  const result = await db
     .update(issuesTable)
     .set({ shareToken: token })
-    .where(eq(issuesTable.id, issueId))
+    .where(and(eq(issuesTable.id, issueId), isNull(issuesTable.shareToken)))
+    .returning({ shareToken: issuesTable.shareToken })
+
+  // Another request may have set the token concurrently — re-read
+  if (result.length === 0) {
+    const refreshed = await getProjectOwnedIssue(project.id, issueId)
+    return c.json({
+      success: true,
+      data: { shareToken: refreshed!.shareToken },
+    })
+  }
+
   await invalidateIssueCache(project.id, issueId)
 
   return c.json({

--- a/apps/api/src/routes/share.ts
+++ b/apps/api/src/routes/share.ts
@@ -1,0 +1,87 @@
+import { and, eq } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { db } from '@/db'
+import { getAppSetting } from '@/db/helpers'
+import { issues as issuesTable, projects as projectsTable } from '@/db/schema'
+import { issueEngine } from '@/engines/issue'
+import { DEFAULT_LOG_PAGE_SIZE, LOG_PAGE_SIZE_KEY } from '@/engines/issue/constants'
+import { serializeIssue } from './issues/_shared'
+
+const share = new Hono()
+
+/** Lookup an issue by its share token — returns null if not found or deleted. */
+async function findByShareToken(token: string) {
+  const [row] = await db
+    .select({
+      issue: issuesTable,
+      projectName: projectsTable.name,
+      projectAlias: projectsTable.alias,
+    })
+    .from(issuesTable)
+    .innerJoin(projectsTable, eq(issuesTable.projectId, projectsTable.id))
+    .where(
+      and(
+        eq(issuesTable.shareToken, token),
+        eq(issuesTable.isDeleted, 0),
+        eq(projectsTable.isDeleted, 0),
+      ),
+    )
+  return row ?? null
+}
+
+// GET /api/share/:token — Get shared issue (public, no auth)
+share.get('/:token', async (c) => {
+  const token = c.req.param('token')!
+  const row = await findByShareToken(token)
+  if (!row) {
+    return c.json({ success: false, error: 'Shared issue not found' }, 404)
+  }
+
+  return c.json({
+    success: true,
+    data: {
+      ...serializeIssue(row.issue),
+      projectName: row.projectName,
+      projectAlias: row.projectAlias,
+    },
+  })
+})
+
+// GET /api/share/:token/logs — Get shared issue logs (public, no auth)
+share.get('/:token/logs', async (c) => {
+  const token = c.req.param('token')!
+  const row = await findByShareToken(token)
+  if (!row) {
+    return c.json({ success: false, error: 'Shared issue not found' }, 404)
+  }
+
+  const issueId = row.issue.id
+  const cursor = c.req.query('cursor') || undefined
+  const before = c.req.query('before') || undefined
+  const limitParam = c.req.query('limit')
+
+  let limit: number | undefined
+  if (limitParam) {
+    limit = Math.min(Math.max(Math.floor(Number(limitParam)) || 30, 1), 1000)
+  } else {
+    const pageSizeRaw = await getAppSetting(LOG_PAGE_SIZE_KEY)
+    limit = pageSizeRaw ? Number(pageSizeRaw) || DEFAULT_LOG_PAGE_SIZE : DEFAULT_LOG_PAGE_SIZE
+  }
+
+  const result = issueEngine.getLogs(issueId, { cursor, before, limit })
+  const isReverse = !cursor
+  const cursorEntry = isReverse ? result.entries[0] : result.entries.at(-1)
+  const nextCursor = result.hasMore && cursorEntry?.messageId ? cursorEntry.messageId : null
+
+  return c.json({
+    success: true,
+    data: {
+      issue: serializeIssue(row.issue),
+      logs: result.entries,
+      nextCursor,
+      hasMore: result.hasMore,
+    },
+  })
+})
+
+export default share

--- a/apps/frontend/src/components/issue-detail/ChatArea.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatArea.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import type { Issue } from '@/types/kanban'
 import { useAutoTitleIssue, useCreateShareToken, useDeleteShareToken, useIssue, useUpdateIssue } from '@/hooks/use-kanban'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useFileBrowserStore } from '@/stores/file-browser-store'
@@ -27,6 +28,7 @@ export function ChatArea({
   showBackToList,
   backPath,
   readOnly,
+  sharedIssue,
   logFetcher,
 }: {
   projectId: string
@@ -41,6 +43,7 @@ export function ChatArea({
   showBackToList?: boolean
   backPath?: string
   readOnly?: boolean
+  sharedIssue?: Issue & { projectName?: string, projectAlias?: string }
   logFetcher?: (opts?: { before?: string, cursor?: string, limit?: number }) => Promise<{
     issue: unknown
     logs: import('@/types/kanban').NormalizedLogEntry[]
@@ -50,7 +53,10 @@ export function ChatArea({
 }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { data: issue, isLoading, isError } = useIssue(projectId, issueId)
+  const { data: fetchedIssue, isLoading: fetchLoading, isError: fetchError } = useIssue(projectId, issueId, { enabled: !sharedIssue })
+  const issue = sharedIssue ?? fetchedIssue
+  const isLoading = !sharedIssue && fetchLoading
+  const isError = !sharedIssue && fetchError
   const scrollRef = useRef<HTMLDivElement>(null)
   const [showSubIssue, setShowSubIssue] = useState(false)
   const [copied, setCopied] = useState(false)

--- a/apps/frontend/src/components/issue-detail/ChatArea.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatArea.tsx
@@ -1,9 +1,10 @@
-import { ArrowLeft, Check, Link, Plus, Sparkles } from 'lucide-react'
+import { ArrowLeft, Check, ExternalLink, Link, Plus, Sparkles } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { useAutoTitleIssue, useIssue, useUpdateIssue } from '@/hooks/use-kanban'
+import { useAutoTitleIssue, useCreateShareToken, useDeleteShareToken, useIssue, useUpdateIssue } from '@/hooks/use-kanban'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useFileBrowserStore } from '@/stores/file-browser-store'
 import { getIssueUrl } from '@/stores/server-store'
@@ -25,6 +26,8 @@ export function ChatArea({
   onFileBrowserWidthChange,
   showBackToList,
   backPath,
+  readOnly,
+  logFetcher,
 }: {
   projectId: string
   issueId: string
@@ -37,6 +40,13 @@ export function ChatArea({
   onFileBrowserWidthChange: (w: number) => void
   showBackToList?: boolean
   backPath?: string
+  readOnly?: boolean
+  logFetcher?: (opts?: { before?: string, cursor?: string, limit?: number }) => Promise<{
+    issue: unknown
+    logs: import('@/types/kanban').NormalizedLogEntry[]
+    hasMore: boolean
+    nextCursor: string | null
+  }>
 }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -49,6 +59,24 @@ export function ChatArea({
   const isMobile = useIsMobile()
   const showFileBrowser = useFileBrowserStore(s => s.isOpen && !s.isDrawer && s.issueId === issueId)
   const closeFileBrowser = useFileBrowserStore(s => s.close)
+
+  const createShareToken = useCreateShareToken(projectId)
+  const deleteShareToken = useDeleteShareToken(projectId)
+
+  const handleShare = useCallback(() => {
+    createShareToken.mutate(issueId, {
+      onSuccess: (data) => {
+        const url = `${window.location.origin}/share/${data.shareToken}`
+        navigator.clipboard.writeText(url).then(() => {
+          toast.success(t('issue.shareLinkCopied'))
+        }).catch(() => {})
+      },
+    })
+  }, [createShareToken, issueId, t])
+
+  const handleUnshare = useCallback(() => {
+    deleteShareToken.mutate(issueId)
+  }, [deleteShareToken, issueId])
 
   const updateIssue = useUpdateIssue(projectId)
   const autoTitle = useAutoTitleIssue(projectId)
@@ -173,7 +201,7 @@ export function ChatArea({
                 #
                 {issue.issueNumber}
               </span>
-              {editingTitle ?
+              {!readOnly && editingTitle ?
                   (
                     <input
                       className="text-sm font-semibold bg-transparent border-b-2 border-primary outline-none min-w-0 flex-1 tracking-tight"
@@ -193,61 +221,81 @@ export function ChatArea({
                   ) :
                   (
                     <span
-                      className="text-sm font-semibold truncate cursor-pointer hover:text-primary transition-colors duration-200 tracking-tight decoration-primary/30 hover:underline underline-offset-2"
-                      onClick={startEditingTitle}
-                      title={t('issue.editTitle')}
+                      className={`text-sm font-semibold truncate tracking-tight ${readOnly ? '' : 'cursor-pointer hover:text-primary transition-colors duration-200 decoration-primary/30 hover:underline underline-offset-2'}`}
+                      onClick={readOnly ? undefined : startEditingTitle}
+                      title={readOnly ? undefined : t('issue.editTitle')}
                     >
                       {issue.title}
                     </span>
                   )}
             </div>
           </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className={`h-7 w-7 shrink-0 transition-colors ${
-              isAutoTitling ?
-                'text-violet-600 dark:text-violet-400 animate-pulse' :
-                issue.sessionStatus ?
-                  'text-muted-foreground hover:text-violet-600 dark:hover:text-violet-400' :
-                  'text-muted-foreground/30 cursor-not-allowed'
-            }`}
-            title={t('issue.autoTitle')}
-            disabled={!issue.sessionStatus || isAutoTitling}
-            onClick={handleAutoTitle}
-          >
-            <Sparkles className="h-3.5 w-3.5" />
-          </Button>
-          {!issue.parentIssueId ?
+          {readOnly ?
               (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground transition-colors"
-                  title={t('issue.createSubIssue')}
-                  onClick={() => setShowSubIssue(true)}
-                >
-                  <Plus className="h-3.5 w-3.5" />
-                </Button>
+                <span className="text-[10px] font-medium text-muted-foreground bg-muted/60 rounded px-1.5 py-0.5 shrink-0">
+                  {t('share.readOnly')}
+                </span>
               ) :
-            null}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={`h-7 w-7 shrink-0 transition-all duration-200 ${copied ? 'text-emerald-500 scale-110' : 'text-muted-foreground hover:text-foreground'}`}
-            title={t('issue.copyLink')}
-            onClick={() => {
-              navigator.clipboard
-                .writeText(getIssueUrl(projectId, issueId))
-                .then(() => {
-                  setCopied(true)
-                  setTimeout(setCopied, 2000, false)
-                })
-                .catch(() => {})
-            }}
-          >
-            {copied ? <Check className="h-3.5 w-3.5" /> : <Link className="h-3.5 w-3.5" />}
-          </Button>
+              (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={`h-7 w-7 shrink-0 transition-colors ${
+                      isAutoTitling ?
+                        'text-violet-600 dark:text-violet-400 animate-pulse' :
+                        issue.sessionStatus ?
+                          'text-muted-foreground hover:text-violet-600 dark:hover:text-violet-400' :
+                          'text-muted-foreground/30 cursor-not-allowed'
+                    }`}
+                    title={t('issue.autoTitle')}
+                    disabled={!issue.sessionStatus || isAutoTitling}
+                    onClick={handleAutoTitle}
+                  >
+                    <Sparkles className="h-3.5 w-3.5" />
+                  </Button>
+                  {!issue.parentIssueId ?
+                      (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+                          title={t('issue.createSubIssue')}
+                          onClick={() => setShowSubIssue(true)}
+                        >
+                          <Plus className="h-3.5 w-3.5" />
+                        </Button>
+                      ) :
+                    null}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={`h-7 w-7 shrink-0 transition-all duration-200 ${issue.shareToken ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground hover:text-foreground'}`}
+                    title={issue.shareToken ? t('issue.unshare') : t('issue.shareLink')}
+                    disabled={createShareToken.isPending || deleteShareToken.isPending}
+                    onClick={issue.shareToken ? handleUnshare : handleShare}
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={`h-7 w-7 shrink-0 transition-all duration-200 ${copied ? 'text-emerald-500 scale-110' : 'text-muted-foreground hover:text-foreground'}`}
+                    title={t('issue.copyLink')}
+                    onClick={() => {
+                      navigator.clipboard
+                        .writeText(getIssueUrl(projectId, issueId))
+                        .then(() => {
+                          setCopied(true)
+                          setTimeout(setCopied, 2000, false)
+                        })
+                        .catch(() => {})
+                    }}
+                  >
+                    {copied ? <Check className="h-3.5 w-3.5" /> : <Link className="h-3.5 w-3.5" />}
+                  </Button>
+                </>
+              )}
         </div>
 
         {/* Shared chat body: messages + metadata bar + input */}
@@ -259,6 +307,8 @@ export function ChatArea({
           onToggleDiff={onToggleDiff}
           scrollRef={scrollRef}
           onAfterDelete={handleAfterDelete}
+          readOnly={readOnly}
+          logFetcher={logFetcher}
         />
       </div>
 
@@ -346,13 +396,17 @@ export function ChatArea({
           )
         : null}
 
-      {/* Sub-issue dialog */}
-      <SubIssueDialog
-        projectId={projectId}
-        parentIssueId={issueId}
-        open={showSubIssue}
-        onOpenChange={setShowSubIssue}
-      />
+      {/* Sub-issue dialog (hidden in read-only mode) */}
+      {!readOnly ?
+          (
+            <SubIssueDialog
+              projectId={projectId}
+              parentIssueId={issueId}
+              open={showSubIssue}
+              onOpenChange={setShowSubIssue}
+            />
+          ) :
+        null}
     </div>
   )
 }

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -60,6 +60,12 @@ export function useSessionState(
   projectId: string,
   issueId: string | null,
   issue: Issue | null | undefined,
+  logFetcher?: (opts?: { before?: string, cursor?: string, limit?: number }) => Promise<{
+    issue: unknown
+    logs: NormalizedLogEntry[]
+    hasMore: boolean
+    nextCursor: string | null
+  }>,
 ) {
   const hasSession = !!issue?.sessionStatus
   const isTodo = issue?.statusId === 'todo'
@@ -80,6 +86,7 @@ export function useSessionState(
     issueId: streamEnabled ? issueId : null,
     sessionStatus: issue?.sessionStatus ?? null,
     enabled: !!(issueId && streamEnabled),
+    logFetcher,
   })
 
   // Merge SSE-derived status with React Query status for resilience.
@@ -128,6 +135,8 @@ export function ChatBody({
   onToggleDiff,
   scrollRef: externalScrollRef,
   onAfterDelete,
+  readOnly,
+  logFetcher,
 }: {
   projectId: string
   issueId: string
@@ -136,6 +145,13 @@ export function ChatBody({
   onToggleDiff: () => void
   scrollRef?: React.RefObject<HTMLDivElement | null>
   onAfterDelete?: () => void
+  readOnly?: boolean
+  logFetcher?: (opts?: { before?: string, cursor?: string, limit?: number }) => Promise<{
+    issue: unknown
+    logs: NormalizedLogEntry[]
+    hasMore: boolean
+    nextCursor: string | null
+  }>
 }) {
   const { t } = useTranslation()
   const internalScrollRef = useRef<HTMLDivElement>(null)
@@ -181,7 +197,7 @@ export function ChatBody({
     refreshLogs,
     removeEntries,
     appendServerMessage,
-  } = useSessionState(projectId, issueId, issue)
+  } = useSessionState(projectId, issueId, issue, logFetcher)
 
   const handleEditPending = useCallback(async (messageId: string) => {
     try {
@@ -312,68 +328,80 @@ export function ChatBody({
         </div>
       </div>
 
-      {/* Issue metadata bar — fixed above input */}
-      <IssueDetail
-        issue={issue}
-        projectId={projectId}
-        status={STATUS_MAP.get(issue.statusId)}
-        onUpdate={fields => updateIssue.mutate({ id: issueId, ...fields })}
-        onDelete={handleDelete}
-        isDeleting={deleteIssueMutation.isPending}
-      />
+      {/* Issue metadata bar — fixed above input (hidden in read-only mode) */}
+      {!readOnly ?
+          (
+            <IssueDetail
+              issue={issue}
+              projectId={projectId}
+              status={STATUS_MAP.get(issue.statusId)}
+              onUpdate={fields => updateIssue.mutate({ id: issueId, ...fields })}
+              onDelete={handleDelete}
+              isDeleting={deleteIssueMutation.isPending}
+            />
+          ) :
+        null}
 
-      {/* Input */}
-      <ChatInput
-        projectId={projectId}
-        issueId={issueId}
-        diffOpen={showDiff}
-        onToggleDiff={onToggleDiff}
-        scrollRef={scrollRef}
-        engineType={issue.engineType ?? undefined}
-        model={issue.model ?? undefined}
-        externalSessionId={issue.externalSessionId ?? undefined}
-        sessionStatus={issue.sessionStatus}
-        statusId={issue.statusId}
-        isThinking={isThinking}
-        slashCommands={slashCommands}
-        pluginCommands={pluginCommands}
-        onRefreshLogs={refreshLogs}
-        onMessageSent={(messageId, prompt, metadata) => {
-          appendServerMessage(messageId, prompt, metadata)
-        }}
-        pendingEditContent={pendingEditContent}
-        onPendingEditConsumed={() => setPendingEditContent(null)}
-      />
-
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('issue.delete')}</AlertDialogTitle>
-            <AlertDialogDescription>{t('issue.deleteConfirm')}</AlertDialogDescription>
-            {issue.childCount && issue.childCount > 0 ?
-                (
-                  <AlertDialogDescription className="text-destructive">
-                    {t('issue.deleteWithChildren')}
-                  </AlertDialogDescription>
-                ) :
-              null}
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteIssueMutation.isPending}>
-              {t('common.cancel')}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              disabled={deleteIssueMutation.isPending}
-              onClick={(event) => {
-                event.preventDefault()
-                handleConfirmDelete()
+      {/* Input (hidden in read-only mode) */}
+      {!readOnly ?
+          (
+            <ChatInput
+              projectId={projectId}
+              issueId={issueId}
+              diffOpen={showDiff}
+              onToggleDiff={onToggleDiff}
+              scrollRef={scrollRef}
+              engineType={issue.engineType ?? undefined}
+              model={issue.model ?? undefined}
+              externalSessionId={issue.externalSessionId ?? undefined}
+              sessionStatus={issue.sessionStatus}
+              statusId={issue.statusId}
+              isThinking={isThinking}
+              slashCommands={slashCommands}
+              pluginCommands={pluginCommands}
+              onRefreshLogs={refreshLogs}
+              onMessageSent={(messageId, prompt, metadata) => {
+                appendServerMessage(messageId, prompt, metadata)
               }}
-            >
-              {deleteIssueMutation.isPending ? t('issue.deleting') : t('issue.delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+              pendingEditContent={pendingEditContent}
+              onPendingEditConsumed={() => setPendingEditContent(null)}
+            />
+          ) :
+        null}
+
+      {!readOnly ?
+          (
+            <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{t('issue.delete')}</AlertDialogTitle>
+                  <AlertDialogDescription>{t('issue.deleteConfirm')}</AlertDialogDescription>
+                  {issue.childCount && issue.childCount > 0 ?
+                      (
+                        <AlertDialogDescription className="text-destructive">
+                          {t('issue.deleteWithChildren')}
+                        </AlertDialogDescription>
+                      ) :
+                    null}
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={deleteIssueMutation.isPending}>
+                    {t('common.cancel')}
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    disabled={deleteIssueMutation.isPending}
+                    onClick={(event) => {
+                      event.preventDefault()
+                      handleConfirmDelete()
+                    }}
+                  >
+                    {deleteIssueMutation.isPending ? t('issue.deleting') : t('issue.delete')}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          ) :
+        null}
     </>
   )
 }

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -283,17 +283,17 @@ export function ChatBody({
                 engineType={issue.engineType ?? undefined}
                 isRunning={isThinking}
                 workingStep={workingStep}
-                onCancel={() => {
+                onCancel={readOnly ? undefined : () => {
                   setIsCancelling(true)
                   cancelIssue.mutate(issueId, {
                     onError: () => setIsCancelling(false),
                   })
                 }}
-                isCancelling={isCancelling}
+                isCancelling={readOnly ? false : isCancelling}
                 hasOlderLogs={hasOlderLogs}
                 isLoadingOlder={isLoadingOlder}
                 onLoadOlder={loadOlderLogs}
-                onEditPending={handleEditPending}
+                onEditPending={readOnly ? undefined : handleEditPending}
               />
             </Suspense>
           </div>

--- a/apps/frontend/src/hooks/use-issue-stream.ts
+++ b/apps/frontend/src/hooks/use-issue-stream.ts
@@ -5,11 +5,20 @@ import { kanbanApi } from '@/lib/kanban-api'
 import type { NormalizedLogEntry, SessionStatus } from '@/types/kanban'
 import { queryKeys } from './use-kanban'
 
+type LogFetcher = (opts?: { before?: string, cursor?: string, limit?: number }) => Promise<{
+  issue: unknown
+  logs: NormalizedLogEntry[]
+  hasMore: boolean
+  nextCursor: string | null
+}>
+
 interface UseIssueStreamOptions {
   projectId: string
   issueId: string | null
   sessionStatus?: SessionStatus | null
   enabled?: boolean
+  /** Override the default log fetcher (used for shared/read-only views) */
+  logFetcher?: LogFetcher
 }
 
 interface UseIssueStreamReturn {
@@ -81,6 +90,7 @@ export function useIssueStream({
   issueId,
   sessionStatus: externalStatus,
   enabled = true,
+  logFetcher,
 }: UseIssueStreamOptions): UseIssueStreamReturn {
   // Live logs: initial load + SSE entries, capped at MAX_LIVE_LOGS
   const [liveLogs, setLiveLogs] = useState<NormalizedLogEntry[]>([])
@@ -265,8 +275,8 @@ export function useIssueStream({
     if (!issueId || !olderCursorRef.current || isLoadingOlder) return
     setIsLoadingOlder(true)
 
-    kanbanApi
-      .getIssueLogs(projectId, issueId, { before: olderCursorRef.current })
+    const fetcher = logFetcher ?? ((opts?: { before?: string }) => kanbanApi.getIssueLogs(projectId, issueId, opts))
+    fetcher({ before: olderCursorRef.current ?? undefined })
       .then((data) => {
         if (!data.logs.length) {
           setHasOlderLogs(false)
@@ -292,7 +302,7 @@ export function useIssueStream({
       .finally(() => {
         setIsLoadingOlder(false)
       })
-  }, [projectId, issueId, isLoadingOlder])
+  }, [projectId, issueId, isLoadingOlder, logFetcher])
 
   useEffect(() => {
     if (!issueId || !enabled) {
@@ -329,8 +339,8 @@ export function useIssueStream({
     const scope = `${projectId}:${issueId}`
     let cancelled = false
 
-    kanbanApi
-      .getIssueLogs(projectId, issueId)
+    const initialFetcher = logFetcher ?? (() => kanbanApi.getIssueLogs(projectId, issueId))
+    initialFetcher()
       .then((data) => {
         if (cancelled || streamScopeRef.current !== scope) return
 
@@ -375,7 +385,7 @@ export function useIssueStream({
     // race: the HTTP response can overwrite SSE entries that arrived between
     // the request and response, making messages appear/disappear/reappear.
     // refreshCounter is included so that refreshLogs() can trigger a re-fetch.
-  }, [projectId, issueId, enabled, markSeen, _refreshCounter])
+  }, [projectId, issueId, enabled, markSeen, _refreshCounter, logFetcher])
 
   // Subscribe to live SSE events for this issue.
   useEffect(() => {

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -42,6 +42,7 @@ export const queryKeys = {
   reviewIssues: () => ['issues', 'review'] as const,
   webhooks: () => ['settings', 'webhooks'] as const,
   webhookDeliveries: (id: string) => ['settings', 'webhooks', id, 'deliveries'] as const,
+  sharedIssue: (token: string) => ['share', token] as const,
 }
 
 export function useProjects() {
@@ -921,6 +922,40 @@ export function useTestWebhook() {
     onSuccess: (_data, id) => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.webhookDeliveries(id),
+      })
+    },
+  })
+}
+
+// --- Share hooks ---
+
+export function useSharedIssue(token: string) {
+  return useQuery({
+    queryKey: queryKeys.sharedIssue(token),
+    queryFn: () => kanbanApi.getSharedIssue(token),
+    enabled: !!token,
+  })
+}
+
+export function useCreateShareToken(projectId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (issueId: string) => kanbanApi.createShareToken(projectId, issueId),
+    onSuccess: (_data, issueId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.issue(projectId, issueId),
+      })
+    },
+  })
+}
+
+export function useDeleteShareToken(projectId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (issueId: string) => kanbanApi.deleteShareToken(projectId, issueId),
+    onSuccess: (_data, issueId) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.issue(projectId, issueId),
       })
     },
   })

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -188,11 +188,12 @@ export function useIssues(projectId: string) {
   })
 }
 
-export function useIssue(projectId: string, issueId: string) {
+export function useIssue(projectId: string, issueId: string, opts?: { enabled?: boolean }) {
+  const enabled = (opts?.enabled ?? true) && !!projectId && !!issueId
   return useQuery({
     queryKey: queryKeys.issue(projectId, issueId),
     queryFn: () => kanbanApi.getIssue(projectId, issueId),
-    enabled: !!projectId && !!issueId,
+    enabled,
   })
 }
 

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -109,7 +109,13 @@
     "delete": "Delete",
     "deleteConfirm": "Are you sure you want to delete this issue? This action cannot be undone.",
     "deleteWithChildren": "This issue has sub-issues that will also be deleted.",
-    "deleting": "Deleting..."
+    "deleting": "Deleting...",
+    "share": "Share",
+    "shareLink": "Share read-only link",
+    "shareLinkCopied": "Share link copied",
+    "unshare": "Stop sharing",
+    "unshareConfirm": "Stop sharing this issue? The shared link will no longer work.",
+    "readOnlyView": "Read-only view"
   },
   "createIssue": {
     "model": "Model",
@@ -427,6 +433,12 @@
     "title": "Review",
     "empty": "No issues pending review",
     "selectToStart": "Select an issue to review"
+  },
+  "share": {
+    "title": "Shared Issue",
+    "notFound": "Shared issue not found or link has expired",
+    "readOnly": "Read-only",
+    "poweredBy": "Powered by BKD"
   },
   "statusName": {
     "Todo": "Todo",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -109,7 +109,13 @@
     "delete": "删除",
     "deleteConfirm": "确定要删除此任务吗？此操作无法撤销。",
     "deleteWithChildren": "此任务包含子任务，子任务也将一并删除。",
-    "deleting": "删除中..."
+    "deleting": "删除中...",
+    "share": "分享",
+    "shareLink": "分享只读链接",
+    "shareLinkCopied": "分享链接已复制",
+    "unshare": "取消分享",
+    "unshareConfirm": "确定取消分享此任务？分享链接将失效。",
+    "readOnlyView": "只读视图"
   },
   "createIssue": {
     "model": "模型",
@@ -427,6 +433,12 @@
     "title": "待审核",
     "empty": "没有待审核的任务",
     "selectToStart": "选择一个任务进行审核"
+  },
+  "share": {
+    "title": "分享的任务",
+    "notFound": "分享的任务未找到或链接已过期",
+    "readOnly": "只读",
+    "poweredBy": "由 BKD 提供"
   },
   "statusName": {
     "Todo": "待办",

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -471,6 +471,32 @@ export const kanbanApi = {
     get<WebhookDelivery[]>(`/api/settings/webhooks/${id}/deliveries`),
   testWebhook: (id: string) => post<{ sent: boolean }>(`/api/settings/webhooks/${id}/test`, {}),
 
+  // Share
+  createShareToken: (projectId: string, issueId: string) =>
+    post<{ shareToken: string }>(
+      `/api/projects/${projectId}/issues/${issueId}/share`,
+      {},
+    ),
+  deleteShareToken: (projectId: string, issueId: string) =>
+    del<null>(`/api/projects/${projectId}/issues/${issueId}/share`),
+  getSharedIssue: (token: string) =>
+    get<Issue & { projectName: string, projectAlias: string }>(
+      `/api/share/${token}`,
+    ),
+  getSharedIssueLogs: (
+    token: string,
+    opts?: { before?: string, cursor?: string, limit?: number },
+  ) => {
+    const params = new URLSearchParams()
+    if (opts?.before) params.set('before', opts.before)
+    if (opts?.cursor) params.set('cursor', opts.cursor)
+    if (opts?.limit) params.set('limit', String(opts.limit))
+    const qs = params.toString()
+    return get<IssueLogsResponse>(
+      `/api/share/${token}/logs${qs ? `?${qs}` : ''}`,
+    )
+  },
+
   // Notes
   getNotes: () => get<Note[]>('/api/notes'),
   createNote: (data: { title?: string, content?: string }) => post<Note>('/api/notes', data),

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -54,6 +54,7 @@ const HomePage = lazy(() => import('./pages/HomePage'))
 const KanbanPage = lazy(() => import('./pages/KanbanPage'))
 const IssueDetailPage = lazy(() => import('./pages/IssueDetailPage'))
 const ReviewPage = lazy(() => import('./pages/ReviewPage'))
+const SharedIssuePage = lazy(() => import('./pages/SharedIssuePage'))
 const TerminalPage = lazy(() => import('./pages/TerminalPage'))
 const LazyTerminalDrawer = lazy(() =>
   import('./components/terminal/TerminalDrawer').then(m => ({
@@ -218,6 +219,14 @@ if (!rootElement.innerHTML) {
                   element={(
                     <ErrorBoundary>
                       <TerminalPage />
+                    </ErrorBoundary>
+                  )}
+                />
+                <Route
+                  path="/share/:token"
+                  element={(
+                    <ErrorBoundary>
+                      <SharedIssuePage />
                     </ErrorBoundary>
                   )}
                 />

--- a/apps/frontend/src/pages/SharedIssuePage.tsx
+++ b/apps/frontend/src/pages/SharedIssuePage.tsx
@@ -61,6 +61,7 @@ export default function SharedIssuePage() {
         fileBrowserWidth={fileBrowserWidth}
         onFileBrowserWidthChange={handleFileBrowserWidthChange}
         readOnly
+        sharedIssue={issue}
         logFetcher={logFetcher}
       />
     </div>

--- a/apps/frontend/src/pages/SharedIssuePage.tsx
+++ b/apps/frontend/src/pages/SharedIssuePage.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
+import { ChatArea } from '@/components/issue-detail/ChatArea'
+import { useSharedIssue } from '@/hooks/use-kanban'
+import { kanbanApi } from '@/lib/kanban-api'
+
+export default function SharedIssuePage() {
+  const { t } = useTranslation()
+  const { token = '' } = useParams<{ token: string }>()
+
+  const { data: issue, isLoading, isError } = useSharedIssue(token)
+
+  const [showDiff, setShowDiff] = useState(false)
+  const [diffWidth, setDiffWidth] = useState(360)
+  const [fileBrowserWidth, setFileBrowserWidth] = useState(360)
+
+  // Create a log fetcher that uses the share token API
+  const logFetcher = useMemo(
+    () => (opts?: { before?: string, cursor?: string, limit?: number }) =>
+      kanbanApi.getSharedIssueLogs(token, opts),
+    [token],
+  )
+
+  const handleDiffWidthChange = useCallback((w: number) => {
+    setDiffWidth(Math.max(240, Math.min(w, 800)))
+  }, [])
+
+  const handleFileBrowserWidthChange = useCallback((w: number) => {
+    setFileBrowserWidth(Math.max(240, Math.min(w, 800)))
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center bg-background text-foreground">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    )
+  }
+
+  if (isError || !issue) {
+    return (
+      <div className="flex h-full items-center justify-center bg-background">
+        <div className="text-center">
+          <p className="text-sm text-muted-foreground">{t('share.notFound')}</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full bg-background text-foreground overflow-hidden animate-page-enter">
+      <ChatArea
+        projectId={issue.projectId}
+        issueId={issue.id}
+        showDiff={showDiff}
+        diffWidth={diffWidth}
+        onToggleDiff={() => setShowDiff(v => !v)}
+        onDiffWidthChange={handleDiffWidthChange}
+        onCloseDiff={() => setShowDiff(false)}
+        fileBrowserWidth={fileBrowserWidth}
+        onFileBrowserWidthChange={handleFileBrowserWidthChange}
+        readOnly
+        logFetcher={logFetcher}
+      />
+    </div>
+  )
+}

--- a/docs/plan/PLAN-024.md
+++ b/docs/plan/PLAN-024.md
@@ -1,0 +1,36 @@
+# PLAN-024 Issue Read-Only Share via Token
+
+- **Status**: completed
+- **Task**: FEAT-004
+
+## Context
+
+Users need to share issue execution results with external systems. Current URLs point to the full editable view. A token-based read-only URL provides a clean, revocable sharing mechanism.
+
+## Design
+
+### DB Changes
+- Add `share_token` (text, nullable, unique index) to `issues` table
+- Migration: `ALTER TABLE issues ADD COLUMN share_token TEXT`
+- Token format: nanoid 12-char alphanumeric
+
+### API Endpoints
+- `POST /api/projects/:projectId/issues/:id/share` → generates token, returns `{ shareToken, shareUrl }`
+- `DELETE /api/projects/:projectId/issues/:id/share` → clears token
+- `GET /api/share/:token` → returns issue data (no auth needed)
+- `GET /api/share/:token/logs` → returns logs with pagination (no auth needed)
+
+### Frontend
+- Route: `/share/:token` → `SharedIssuePage`
+- ChatArea: add `readOnly` prop to hide edit/action controls
+- ChatBody: hide ChatInput, delete, cancel when readOnly
+- Share button in title bar: generates token + copies URL
+
+## Steps
+
+1. Schema + migration
+2. API routes
+3. Shared types
+4. Frontend page + components
+5. i18n
+6. Test

--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -26,3 +26,4 @@
 - [x] **PLAN-021 禁止会话内 follow-up 切换模型** - task: `ENG-012` - owner: codex - file: `docs/plan/PLAN-021.md`
 - [x] **PLAN-022 修复 ACP 重复占位 tool action 发射** - task: `BUG-011` - owner: codex - file: `docs/plan/PLAN-022.md`
 - [x] **PLAN-023 Keep pending messages separate and editable** - task: `BUG-012` - owner: local - file: `docs/plan/PLAN-023.md`
+- [-] **PLAN-024 Issue Read-Only Share via Token** - task: `FEAT-004` - owner: claude - file: `docs/plan/PLAN-024.md`

--- a/docs/task/FEAT-004.md
+++ b/docs/task/FEAT-004.md
@@ -1,0 +1,17 @@
+# FEAT-004 Issue Read-Only Share via Token
+
+- **Status**: completed
+- **Priority**: P1
+- **Owner**: claude
+- **Plan**: PLAN-024
+
+## Description
+
+Add a shareable read-only URL for issues using random tokens. External systems can view execution results via `/share/:token` without needing project context.
+
+## Scope
+
+- DB schema: `shareToken` field on `issues` table
+- API: generate/delete/query share token endpoints
+- Frontend: read-only page, share button, ChatArea readOnly mode
+- i18n keys for both en/zh

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -15,6 +15,7 @@
 - [x] **FEAT-001 添加 server_name 和 server_url 环境变量** `P2` - file: `docs/task/FEAT-001.md`
 - [x] **FEAT-002 将 SERVER_NAME 和 SERVER_URL 从环境变量迁移到数据库** `P2` - owner: claude - file: `docs/task/FEAT-002.md`
 - [x] **FEAT-003 MAX_CONCURRENT_EXECUTIONS 可通过设置配置** `P2` - owner: claude - plan: `PLAN-006` - file: `docs/task/FEAT-003.md`
+- [x] **FEAT-004 Issue Read-Only Share via Token** `P1` - owner: claude - plan: `PLAN-024` - file: `docs/task/FEAT-004.md`
 
 ## Engineering
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -47,6 +47,7 @@ export interface Issue {
   prompt: string | null
   externalSessionId: string | null
   model: string | null
+  shareToken: string | null
   totalInputTokens: number
   totalOutputTokens: number
   totalCostUsd: string


### PR DESCRIPTION
## Summary

- Add token-based read-only sharing for issues, allowing external systems to view execution results via `/share/:token` without project context
- DB migration adds `shareToken` field with unique index; project-scoped `POST/DELETE` endpoints manage token lifecycle; public `GET` endpoints serve issue data and paginated logs
- Frontend adds `SharedIssuePage` at `/share/:token` route, reusing `ChatArea`/`ChatBody` with a `readOnly` prop that hides all edit controls, plus a share button in the title bar

## Test plan

- [x] API tests pass (475/475, 1 pre-existing failure unrelated)
- [x] Frontend tests pass (36/36)
- [x] Lint passes
- [x] Build passes
- [ ] Manual: create issue, click share button, verify token URL opens read-only view
- [ ] Manual: click share button again (unshare), verify token URL returns 404