### PR TITLE
docs: add API reference documentation

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -4,7 +4,7 @@ Base URL: `/api`
 
 ## Response Envelope
 
-All responses use a standard envelope:
+Most JSON CRUD responses use a standard envelope. Exceptions include binary/file download endpoints (which return raw streams) and `/api/runtime` (which returns a raw object).
 
 ```json
 { "success": true, "data": T }
@@ -31,7 +31,7 @@ All POST/PATCH routes use Zod schema validation via `@hono/zod-validator`. Valid
 
 ## Soft Deletion
 
-All DELETE operations use `isDeleted` flag — data is never hard-deleted.
+Database-backed DELETE operations (projects, issues, notes, etc.) use an `isDeleted` flag — data is never hard-deleted. However, some endpoints perform **irreversible** deletions: file DELETE (`/api/files/*`) removes files from disk, and worktree DELETE (`/api/worktrees/*`) physically removes Git worktrees.
 
 ## Security
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,64 @@
+# BKD API Reference
+
+Base URL: `/api`
+
+## Response Envelope
+
+All responses use a standard envelope:
+
+```json
+{ "success": true, "data": T }
+{ "success": false, "error": "message" }
+```
+
+## Status Codes
+
+| Code | Meaning |
+|---|---|
+| `200` | OK |
+| `201` | Created |
+| `202` | Accepted (async operation started) |
+| `400` | Bad Request (validation error) |
+| `403` | Forbidden |
+| `404` | Not Found |
+| `409` | Conflict |
+| `429` | Too Many Requests |
+| `500` | Internal Server Error |
+
+## Validation
+
+All POST/PATCH routes use Zod schema validation via `@hono/zod-validator`. Validation errors return `400` with comma-separated error messages.
+
+## Soft Deletion
+
+All DELETE operations use `isDeleted` flag — data is never hard-deleted.
+
+## Security
+
+- Workspace root boundary validation (SEC-016)
+- Git command injection prevention (SEC-019)
+- Workspace directory confinement (SEC-022)
+- XSS prevention via `Content-Disposition: attachment` (SEC-024)
+- Symlink traversal prevention via `realpath()` (SEC-025)
+
+## Sections
+
+| Document | Description |
+|---|---|
+| [system.md](./system.md) | Health check, status, runtime |
+| [projects.md](./projects.md) | Project CRUD, archive, sort |
+| [issues.md](./issues.md) | Issue CRUD, bulk update |
+| [execution.md](./execution.md) | Execute, follow-up, restart, cancel |
+| [logs.md](./logs.md) | Issue logs (paginated) |
+| [changes.md](./changes.md) | Git changes and file diffs |
+| [attachments.md](./attachments.md) | File attachments |
+| [engines.md](./engines.md) | Engine discovery, models, settings |
+| [events.md](./events.md) | Server-Sent Events (SSE) |
+| [files.md](./files.md) | File browser, read, write, delete |
+| [terminal.md](./terminal.md) | PTY sessions, WebSocket |
+| [processes.md](./processes.md) | Engine process management |
+| [worktrees.md](./worktrees.md) | Git worktree management |
+| [git.md](./git.md) | Git utilities |
+| [filesystem.md](./filesystem.md) | Directory browsing and creation |
+| [notes.md](./notes.md) | Notes CRUD |
+| [settings.md](./settings.md) | System settings |

--- a/docs/api/attachments.md
+++ b/docs/api/attachments.md
@@ -1,0 +1,9 @@
+# Attachments
+
+## GET /api/projects/:projectId/issues/:id/attachments/:attachmentId
+
+Download an attachment file.
+
+Returns raw file stream with `Content-Disposition: attachment` header.
+
+Path is validated to stay within the upload directory (SEC-025).

--- a/docs/api/changes.md
+++ b/docs/api/changes.md
@@ -1,0 +1,37 @@
+# Issue Changes
+
+## GET /api/projects/:projectId/issues/:id/changes
+
+Get git changes summary for an issue.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "root": "/path/to/repo",
+    "gitRepo": true,
+    "files": [{ "path": "...", "status": "...", "type": "...", "staged": true, "additions": 5, "deletions": 2 }],
+    "additions": 10,
+    "deletions": 5
+  }
+}
+```
+
+## GET /api/projects/:projectId/issues/:id/changes/file
+
+Get diff for a specific file.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `path` | `string` | File path (no leading `-` or `:`) |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": { "path": "...", "patch": "...", "oldText": "...", "newText": "...", "truncated": false, "type": "...", "status": "..." }
+}
+```

--- a/docs/api/engines.md
+++ b/docs/api/engines.md
@@ -1,0 +1,49 @@
+# Engines
+
+## GET /api/engines/available
+
+List detected engines and their models. Uses 3-tier cache (memory -> DB -> live probe).
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "engines": [{ "name": "claude-code", "available": true, "isAvailable": true }],
+    "models": [{ "id": "...", "name": "...", "provider": "...", "isDefault": true }]
+  }
+}
+```
+
+## GET /api/engines/profiles
+
+List engine profiles.
+
+## GET /api/engines/settings
+
+Get engine default settings.
+
+**Response:** `{ defaultEngine, engines: { [engineType]: { defaultModel } } }`
+
+## PATCH /api/engines/default-engine
+
+Set the global default engine.
+
+**Request Body:** `{ defaultEngine: "claude-code" | "codex" | "acp" | "echo" }`
+
+## GET /api/engines/:engineType/models
+
+List models for a specific engine.
+
+**Response:** `{ engineType, defaultModel, models }`
+
+## PATCH /api/engines/:engineType/settings
+
+Set an engine's default model.
+
+**Request Body:** `{ defaultModel: string }`
+
+## POST /api/engines/probe
+
+Force live re-probe of all engines.

--- a/docs/api/engines.md
+++ b/docs/api/engines.md
@@ -10,11 +10,30 @@ List detected engines and their models. Uses 3-tier cache (memory -> DB -> live 
 {
   "success": true,
   "data": {
-    "engines": [{ "name": "claude-code", "available": true, "isAvailable": true }],
-    "models": [{ "id": "...", "name": "...", "provider": "...", "isDefault": true }]
+    "engines": [
+      {
+        "engineType": "claude-code",
+        "installed": true,
+        "executable": true,
+        "version": "1.0.0",
+        "binaryPath": "/usr/local/bin/claude",
+        "authStatus": "authenticated"
+      }
+    ],
+    "models": {
+      "claude-code": [
+        { "id": "opus", "name": "Opus", "isDefault": true },
+        { "id": "sonnet", "name": "Sonnet" }
+      ],
+      "codex": [
+        { "id": "o3", "name": "o3", "isDefault": true }
+      ]
+    }
   }
 }
 ```
+
+`engines` items follow `EngineAvailability` (`engineType`, `installed`, `executable`, `version`, `binaryPath`, `authStatus`, `error`). `models` is a per-engine map (`Record<string, EngineModel[]>`), not a flat array.
 
 ## GET /api/engines/profiles
 

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -1,0 +1,22 @@
+# Events (SSE)
+
+## GET /api/events
+
+Server-Sent Events stream for real-time updates.
+
+Single global SSE endpoint. Heartbeat every 15s. Reconnects with exponential backoff + 35s watchdog.
+
+Compression is skipped for this route.
+
+## Event Types
+
+| Event | Description |
+|---|---|
+| `log` | New log entry from agent |
+| `log-updated` | Log entry updated |
+| `log-removed` | Log entry removed |
+| `state` | Issue state change |
+| `done` | Issue execution completed |
+| `issue-updated` | Issue metadata updated |
+| `changes-summary` | Git changes summary after settlement |
+| `heartbeat` | Keep-alive (every 15s) |

--- a/docs/api/execution.md
+++ b/docs/api/execution.md
@@ -1,0 +1,71 @@
+# Issue Execution
+
+All routes are scoped under `/api/projects/:projectId/issues/:id`.
+
+## POST .../execute
+
+Start execution with a new prompt.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `engineType` | `"claude-code" \| "codex" \| "acp" \| "echo"` | Yes | Engine type |
+| `prompt` | `string` (1-32768) | Yes | Task prompt |
+| `model` | `string` (1-160) | No | Model identifier |
+| `permissionMode` | `"auto" \| "supervised" \| "plan"` | No | Permission mode |
+
+**Response:** `{ executionId, issueId, messageId }`
+
+## POST .../follow-up
+
+Send a follow-up message. Accepts `application/json` or `multipart/form-data`.
+
+**Request Body (JSON):**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `prompt` | `string` (1-32768) | Yes | Follow-up message |
+| `model` | `string` (1-160) | No | Model override |
+| `permissionMode` | `"auto" \| "supervised" \| "plan"` | No | Permission mode |
+| `busyAction` | `"queue" \| "cancel"` | No | What to do if agent is busy |
+| `meta` | `boolean` | No | Meta command flag |
+| `displayPrompt` | `string` (0-500) | No | Display-only prompt text |
+
+**Multipart:** same fields + `files[]` for attachments.
+
+**Response:** `{ executionId, issueId, messageId, queued?: true }`
+
+## DELETE .../pending
+
+Recall a pending (queued) message.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `messageId` | `string` (ULID) | Message ID to recall |
+
+**Response:** `{ id, content, metadata, attachments }`
+
+## POST .../restart
+
+Restart a failed session.
+
+**Response:** `{ executionId, issueId }`
+
+## POST .../cancel
+
+Cancel active execution.
+
+**Response:** `{ issueId, status }`
+
+## POST .../auto-title
+
+Auto-generate a title using AI.
+
+**Response:** `{ executionId, issueId }`
+
+## GET .../slash-commands
+
+Get available slash commands for the issue's engine.
+
+**Response:** `{ commands, agents, plugins }`

--- a/docs/api/files.md
+++ b/docs/api/files.md
@@ -1,0 +1,66 @@
+# Files
+
+## GET /api/files/show
+
+Get directory listing for the root path.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `root` | `string` | Root directory path (required) |
+| `hideIgnored` | `"true" \| "false"` | Hide git-ignored files |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "path": "...",
+    "type": "directory",
+    "entries": [{ "name": "...", "type": "file|directory", "size": 1234, "modifiedAt": "..." }]
+  }
+}
+```
+
+## GET /api/files/show/*
+
+Get directory listing or file content for a subpath.
+
+**Response (file):**
+
+```json
+{
+  "success": true,
+  "data": { "path": "...", "type": "file", "content": "...", "size": 1234, "isTruncated": false, "isBinary": false }
+}
+```
+
+Max 1 MB file preview. Binary files detected via null-byte check.
+
+## GET /api/files/raw/*
+
+Download raw file. Returns file stream with `Content-Disposition: attachment`.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `root` | `string` | Root directory path |
+
+## PUT /api/files/save/*
+
+Save text file content.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `root` | `string` | Root directory path |
+
+**Request Body:** `{ content: string }` (max 5 MB)
+
+**Response:** `{ size, modifiedAt }`
+
+## DELETE /api/files/delete/*
+
+Delete a file or directory.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `root` | `string` | Root directory path |

--- a/docs/api/filesystem.md
+++ b/docs/api/filesystem.md
@@ -1,0 +1,23 @@
+# Filesystem
+
+All filesystem routes enforce workspace boundary (SEC-022).
+
+## GET /api/filesystem/dirs
+
+List directories.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `path` | `string` | Directory path (defaults to workspace root) |
+
+**Response:** `{ current, parent, dirs }`
+
+## POST /api/filesystem/dirs
+
+Create a directory.
+
+**Request Body:** `{ path: string, name: string (1-255) }`
+
+Name is validated as a basename (no path traversal).
+
+**Response:** `201` with `{ path }`

--- a/docs/api/git.md
+++ b/docs/api/git.md
@@ -1,0 +1,9 @@
+# Git
+
+## POST /api/git/detect-remote
+
+Detect git remote URL from a directory.
+
+**Request Body:** `{ directory: string (1-1000) }`
+
+**Response:** `{ url, remote }`

--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -1,0 +1,80 @@
+# Issues
+
+All issue routes are scoped under `/api/projects/:projectId`.
+
+## GET /api/projects/:projectId/issues
+
+List issues for a project.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `parentId` | `string \| "null"` | Filter by parent issue (use `"null"` for root issues) |
+
+**Response:** `Issue[]` (each includes `childCount`)
+
+## GET /api/projects/:projectId/issues/:id
+
+Get a single issue with its children.
+
+**Response:** `Issue & { children: Issue[] }`
+
+## POST /api/projects/:projectId/issues
+
+Create an issue. Auto-executes if `statusId` is `working` or `review`.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `title` | `string` (1-500) | Yes | Issue title |
+| `tags` | `string[]` | No | Max 10 tags, 50 chars each |
+| `statusId` | `"todo" \| "working" \| "review" \| "done"` | Yes | Initial status |
+| `parentIssueId` | `string` | No | Parent issue ID |
+| `useWorktree` | `boolean` | No | Run in git worktree |
+| `engineType` | `"claude-code" \| "codex" \| "acp" \| "echo"` | No | Engine to use |
+| `model` | `string` (1-160) | No | Model identifier |
+| `permissionMode` | `"auto" \| "supervised" \| "plan"` | No | Permission mode |
+
+**Response:** `201` (or `202` if auto-executing) with `Issue`
+
+## PATCH /api/projects/:projectId/issues/:id
+
+Update an issue.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `title` | `string` (1-500) | No | Issue title |
+| `tags` | `string[] \| null` | No | Tags (null to clear) |
+| `statusId` | `"todo" \| "working" \| "review" \| "done"` | No | Status (triggers execution/cancellation) |
+| `sortOrder` | `string` | No | Fractional sort key |
+| `parentIssueId` | `string \| null` | No | Parent issue (null to unparent) |
+
+## PATCH /api/projects/:projectId/issues/bulk
+
+Bulk update issues.
+
+**Request Body:**
+
+```json
+{
+  "updates": [
+    { "id": "string", "statusId?": "todo|working|review|done", "sortOrder?": "string" }
+  ]
+}
+```
+
+Max 1000 items. Status transitions trigger execution/cancellation.
+
+**Response:** `{ data: Issue[], skipped?: string[] }`
+
+## DELETE /api/projects/:projectId/issues/:id
+
+Soft-delete an issue and its children. Terminates active processes.
+
+## GET /api/issues/review
+
+List all issues in `review` status across all projects (global, not project-scoped).
+
+**Response:** `(Issue & { projectName, projectAlias })[]`

--- a/docs/api/logs.md
+++ b/docs/api/logs.md
@@ -1,0 +1,25 @@
+# Issue Logs
+
+## GET /api/projects/:projectId/issues/:id/logs
+
+Get paginated issue logs.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `cursor` | `string` (ULID) | Cursor for forward pagination |
+| `before` | `string` (ULID) | Cursor for backward pagination |
+| `limit` | `number` (1-1000) | Page size (default: 30) |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "issue": "Issue",
+    "logs": [{ "messageId": "...", "type": "...", "content": "...", "role": "..." }],
+    "nextCursor": "string | null",
+    "hasMore": true
+  }
+}
+```

--- a/docs/api/notes.md
+++ b/docs/api/notes.md
@@ -1,0 +1,28 @@
+# Notes
+
+## GET /api/notes
+
+List all notes.
+
+## POST /api/notes
+
+Create a note.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `title` | `string` (0-500) | No | Note title |
+| `content` | `string` (0-100000) | No | Note content |
+
+**Response:** `201` with `Note`
+
+## PATCH /api/notes/:id
+
+Update a note.
+
+**Request Body:** `{ title?, content?, isPinned?: boolean }`
+
+## DELETE /api/notes/:id
+
+Soft-delete a note.

--- a/docs/api/processes.md
+++ b/docs/api/processes.md
@@ -1,0 +1,36 @@
+# Processes
+
+## GET /api/projects/:projectId/processes
+
+List active engine processes for a project.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "processes": [{
+      "executionId": "...",
+      "issueId": "...",
+      "issueTitle": "...",
+      "issueNumber": 1,
+      "engineType": "claude-code",
+      "processState": "running",
+      "model": "...",
+      "startedAt": "...",
+      "turnInFlight": true,
+      "spawnCommand": "...",
+      "lastIdleAt": "...",
+      "pid": 12345,
+      "transcriptPath": "..."
+    }]
+  }
+}
+```
+
+## POST /api/projects/:projectId/processes/:issueId/terminate
+
+Terminate an engine process.
+
+**Response:** `{ issueId, status: "terminated" }`

--- a/docs/api/projects.md
+++ b/docs/api/projects.md
@@ -1,0 +1,60 @@
+# Projects
+
+## GET /api/projects
+
+List all projects.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `archived` | `"true" \| "false"` | Filter by archive status |
+
+**Response:** `Project[]`
+
+## POST /api/projects
+
+Create a new project.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` (1-200) | Yes | Project name |
+| `alias` | `string` (1-200) | No | URL-friendly alias (lowercase alphanumeric) |
+| `description` | `string` (0-5000) | No | Project description |
+| `directory` | `string` (0-1000) | No | Working directory path |
+| `repositoryUrl` | `string` (URL) | No | Git repository URL |
+| `systemPrompt` | `string` (0-32768) | No | Default system prompt for agents |
+| `envVars` | `Record<string, string>` | No | Environment variables (max 10000 chars per value) |
+
+**Response:** `201` with `Project`
+
+## GET /api/projects/:projectId
+
+Get a single project by ID.
+
+## PATCH /api/projects/:projectId
+
+Update a project. Same fields as POST, all optional.
+
+## DELETE /api/projects/:projectId
+
+Soft-delete a project and all its issues. Terminates active processes.
+
+## POST /api/projects/:projectId/archive
+
+Archive a project.
+
+## POST /api/projects/:projectId/unarchive
+
+Unarchive a project.
+
+## PATCH /api/projects/sort
+
+Update project sort order.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | Yes | Project ID |
+| `sortOrder` | `string` (1-50) | Yes | Fractional sort key |

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -1,0 +1,95 @@
+# Settings
+
+## Workspace
+
+### GET /api/settings/workspace-path
+
+Get workspace root path.
+
+### PATCH /api/settings/workspace-path
+
+Set workspace root path.
+
+**Request Body:** `{ path: string (1-1024) }`
+
+## Write Filter Rules
+
+### GET /api/settings/write-filter-rules
+
+Get write filter rules.
+
+### PUT /api/settings/write-filter-rules
+
+Replace all write filter rules.
+
+**Request Body:** `{ rules: [{ id, type: "tool-name", match, enabled }] }`
+
+### PATCH /api/settings/write-filter-rules/:id
+
+Toggle a single rule.
+
+**Request Body:** `{ enabled: boolean }`
+
+## Worktree Cleanup
+
+### GET /api/settings/worktree-auto-cleanup
+
+Get worktree auto-cleanup setting.
+
+### PATCH /api/settings/worktree-auto-cleanup
+
+Set worktree auto-cleanup.
+
+**Request Body:** `{ enabled: boolean }`
+
+## Log Page Size
+
+### GET /api/settings/log-page-size
+
+Get log pagination page size.
+
+### PATCH /api/settings/log-page-size
+
+Set log pagination page size.
+
+**Request Body:** `{ size: 5-200 }`
+
+## Concurrency
+
+### GET /api/settings/max-concurrent-executions
+
+Get maximum concurrent executions.
+
+### PATCH /api/settings/max-concurrent-executions
+
+Set maximum concurrent executions.
+
+**Request Body:** `{ value: 1-50 }`
+
+## Server Info
+
+### GET /api/settings/server-info
+
+Get server name and URL.
+
+### PATCH /api/settings/server-info
+
+Set server name and URL.
+
+**Request Body:** `{ name?: string (0-128), url?: string (0-1024) }`
+
+## Slash Commands
+
+### GET /api/settings/slash-commands
+
+Get cached slash commands.
+
+| Query Param | Type | Description |
+|---|---|---|
+| `engine` | `string` | Engine type |
+
+## System Info
+
+### GET /api/settings/system-info
+
+Get system information (version, runtime, platform, process PID).

--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -1,0 +1,44 @@
+# System
+
+## GET /api
+
+API status check.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": { "name": "bkd-api", "status": "ok", "routes": [...] }
+}
+```
+
+## GET /api/health
+
+Health check with database status.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": { "status": "ok", "version": "0.0.6", "commit": "abc1234", "db": "ok", "timestamp": "..." }
+}
+```
+
+## GET /api/status
+
+Detailed status with memory metrics.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": { "uptime": 12345, "memory": { "rss": 0, "heapUsed": 0, "heapTotal": 0 }, "db": "ok" }
+}
+```
+
+## GET /api/runtime
+
+Runtime information. Requires `ENABLE_RUNTIME_ENDPOINT=true`.

--- a/docs/api/terminal.md
+++ b/docs/api/terminal.md
@@ -1,0 +1,31 @@
+# Terminal
+
+## POST /api/terminal
+
+Create a new PTY session. Max 10 concurrent sessions.
+
+**Response:** `201` with `{ id }`
+
+## GET /api/terminal/:id
+
+Check if a terminal session is alive.
+
+## GET /api/terminal/ws/:id
+
+WebSocket connection for terminal I/O.
+
+**Binary Protocol:**
+- `[0x00][data]` — input
+- `[0x01][cols:u16][rows:u16]` — resize
+
+Grace period: 60s after disconnect before PTY kill.
+
+## POST /api/terminal/:id/resize
+
+Resize terminal (REST fallback).
+
+**Request Body:** `{ cols: 1-500, rows: 1-200 }`
+
+## DELETE /api/terminal/:id
+
+Kill a terminal session.

--- a/docs/api/worktrees.md
+++ b/docs/api/worktrees.md
@@ -1,0 +1,11 @@
+# Worktrees
+
+## GET /api/projects/:projectId/worktrees
+
+List git worktrees for a project.
+
+**Response:** `[{ issueId, path, branch }]`
+
+## DELETE /api/projects/:projectId/worktrees/:issueId
+
+Force-delete a worktree. Validates `issueId` against `/^[\w-]{4,32}$/`.


### PR DESCRIPTION
## Summary

- Add comprehensive API reference documentation under `docs/api/`
- 18 documents covering all 80+ endpoints, organized by functional area: system, projects, issues, execution, logs, changes, attachments, engines, events, files, terminal, processes, worktrees, git, filesystem, notes, and settings
- Each document includes endpoint paths, request/response schemas, query parameters, and status codes

## Test plan

- [ ] Verify all documented endpoints match actual route definitions
- [ ] Confirm request body schemas match Zod validators in source code