### PR TITLE
feat: add path-based log filtering API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,11 +103,18 @@ POST           /api/projects/:projectId/issues/:id/restart
 POST           /api/projects/:projectId/issues/:id/cancel
 POST           /api/projects/:projectId/issues/:id/messages
 GET            /api/projects/:projectId/issues/:id/logs
+GET            /api/projects/:projectId/issues/:id/logs/filter/*
 GET/POST       /api/projects/:projectId/issues/:id/attachments
 GET            /api/projects/:projectId/issues/:id/changes
 POST           /api/projects/:projectId/issues/:id/auto-title
 GET            /api/projects/:projectId/issues/:id/slash-commands
 ```
+
+The `/logs/filter/*` route accepts path-based key/value filter pairs (order-independent):
+- `types/<comma-separated>` — filter by entry type (`user-message`, `assistant-message`, `tool-use`, `system-message`, `thinking`)
+- `turn/<value>` — filter by turn: single (`3`), range (`2-5`), `last`, or `lastN` (`last3`)
+- Example: `/logs/filter/types/user-message,assistant-message/turn/last3`
+- Pagination via query params: `cursor`, `before`, `limit`
 
 System routes: `/api/engines/*`, `/api/events` (SSE), `/api/settings/*`, `/api/upgrade/*`, `/api/terminal/ws`, `/api/files/*`, `/api/filesystem/*`, `/api/git/*`, `/api/processes/*`, `/api/worktrees/*`.
 

--- a/apps/api/src/engines/issue/engine.ts
+++ b/apps/api/src/engines/issue/engine.ts
@@ -11,7 +11,8 @@ import {
   restartIssue,
   restartStaleSessions,
 } from './orchestration'
-import type { PaginatedLogResult } from './persistence/queries'
+import type { LogQueryOpts, PaginatedLogResult } from './persistence/queries'
+import { getNextTurnIndex } from './persistence/queries'
 import { registerLogPipeline } from './pipeline'
 import { terminateProcess } from './process/cancel'
 import {
@@ -150,13 +151,26 @@ export class IssueEngine {
 
   getLogs(
     issueId: string,
-    opts?: {
-      cursor?: string // ULID id — fetch entries after this
-      before?: string // ULID id — fetch entries before this
-      limit?: number
-    },
+    opts?: LogQueryOpts,
   ): PaginatedLogResult {
     return getLogs(this.ctx, issueId, opts)
+  }
+
+  /**
+   * Get the maximum turn index for an issue, considering both DB and
+   * in-memory ring buffer. Returns -1 if no turns exist anywhere.
+   */
+  getMaxTurnIndex(issueId: string): number {
+    const dbMax = getNextTurnIndex(issueId) - 1
+    const active = this.ctx.pm.getFirstActiveInGroup(issueId)?.meta
+    if (!active || active.logs.length === 0) return dbMax
+    let memMax = -1
+    for (const entry of active.logs.toArray()) {
+      if (entry.turnIndex != null && entry.turnIndex > memMax) {
+        memMax = entry.turnIndex
+      }
+    }
+    return Math.max(dbMax, memMax)
   }
 
   getProcess(executionId: string): ManagedProcess | undefined {

--- a/apps/api/src/engines/issue/persistence/queries.ts
+++ b/apps/api/src/engines/issue/persistence/queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, lt, max, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, gt, gte, inArray, lt, lte, max, sql } from 'drizzle-orm'
 import { db } from '@/db'
 import { issueLogs as logsTable, issuesLogsToolsCall as toolsTable } from '@/db/schema'
 import { MAX_LOG_ENTRIES } from '@/engines/issue/constants'
@@ -9,6 +9,18 @@ import { rawToToolAction } from './tool-detail'
 export interface PaginatedLogResult {
   entries: NormalizedLogEntry[]
   hasMore: boolean
+}
+
+export interface LogQueryOpts {
+  cursor?: string // ULID id — fetch entries strictly after this
+  before?: string // ULID id — fetch entries strictly before this
+  limit?: number
+  /** Filter by specific entry types. When set, only these types are returned. */
+  entryTypes?: string[]
+  /** Inclusive lower bound for turnIndex. */
+  turnIndex?: number
+  /** Inclusive upper bound for turnIndex. */
+  turnIndexEnd?: number
 }
 
 /** Safety cap: max total entries returned per page (prevents extreme tool-use fan-out). */
@@ -26,25 +38,85 @@ const CONVERSATION_MSG_CONDITION = sql`(
   OR ${logsTable.entryType} = 'assistant-message'
 )`
 
+/** Map a DB row + optional tool detail to a NormalizedLogEntry. */
+function rowToEntry(
+  row: typeof logsTable.$inferSelect,
+  toolByLogId: Map<string, typeof toolsTable.$inferSelect>,
+): NormalizedLogEntry {
+  const parsedMeta = row.metadata ? JSON.parse(row.metadata) : undefined
+  const base: NormalizedLogEntry = {
+    messageId: row.id,
+    replyToMessageId: row.replyToMessageId ?? undefined,
+    entryType: row.entryType as NormalizedLogEntry['entryType'],
+    content: row.content.trim(),
+    turnIndex: row.turnIndex,
+    timestamp: row.timestamp ?? undefined,
+    metadata: parsedMeta,
+  }
+
+  const tool = toolByLogId.get(row.id)
+  if (tool) {
+    const rawData = tool.raw ? JSON.parse(tool.raw) : {}
+    base.toolDetail = {
+      kind: tool.kind,
+      toolName: tool.toolName,
+      toolCallId: tool.toolCallId ?? undefined,
+      isResult: tool.isResult ?? false,
+      raw: rawData,
+    }
+    base.toolAction = rawToToolAction(tool.kind, rawData)
+    if (!base.content && rawData.content) {
+      base.content = rawData.content as string
+    }
+    if (!base.metadata && rawData.metadata) {
+      base.metadata = rawData.metadata as Record<string, unknown>
+    }
+  }
+
+  return base
+}
+
+/** Batch-fetch tool details for a set of log rows. */
+function fetchToolDetails(logIds: string[]): Map<string, typeof toolsTable.$inferSelect> {
+  const map = new Map<string, typeof toolsTable.$inferSelect>()
+  if (logIds.length === 0) return map
+  const toolRows = db.select().from(toolsTable).where(inArray(toolsTable.logId, logIds)).all()
+  for (const r of toolRows) map.set(r.logId, r)
+  return map
+}
+
+/** Build shared conditions for turnIndex range and cursor pagination. */
+function applyCommonConditions(conditions: ReturnType<typeof eq>[], opts?: LogQueryOpts): void {
+  if (opts?.turnIndex != null) {
+    conditions.push(gte(logsTable.turnIndex, opts.turnIndex))
+  }
+  if (opts?.turnIndexEnd != null) {
+    conditions.push(lte(logsTable.turnIndex, opts.turnIndexEnd))
+  }
+  if (opts?.cursor) conditions.push(gt(logsTable.id, opts.cursor))
+  else if (opts?.before) conditions.push(lt(logsTable.id, opts.before))
+}
+
 /**
  * Fetch logs from DB with conversation-message-based pagination.
  *
- * Pagination counts only user-message and assistant-message entries
- * (conversation messages) toward the limit, but returns all visible
- * entries within the range — including tool-use and system messages.
+ * When `entryTypes` is provided, pagination and results are both scoped
+ * to those types only (simple single-pass query). Otherwise, the default
+ * two-step approach is used: pagination counts conversation messages
+ * (user + assistant) toward the limit, but returns all visible entries
+ * within the range — including tool-use and system messages.
  *
- * Two-step approach:
- * 1. Find conversation message boundary IDs to determine page range + hasMore
- * 2. Fetch all visible entries within the boundary range
+ * Supports optional turnIndex range filtering.
  */
 export function getLogsFromDb(
   issueId: string,
-  opts?: {
-    cursor?: string // ULID id — fetch entries strictly after this
-    before?: string // ULID id — fetch entries strictly before this
-    limit?: number
-  },
+  opts?: LogQueryOpts,
 ): PaginatedLogResult {
+  // When entryTypes filter is specified, use the simpler single-pass path
+  if (opts?.entryTypes && opts.entryTypes.length > 0) {
+    return getFilteredLogsFromDb(issueId, opts)
+  }
+
   const isReverse = !opts?.cursor
   const effectiveLimit = opts?.limit ?? MAX_LOG_ENTRIES
 
@@ -54,8 +126,7 @@ export function getLogsFromDb(
     eq(logsTable.visible, 1),
     CONVERSATION_MSG_CONDITION,
   ]
-  if (opts?.cursor) convConditions.push(gt(logsTable.id, opts.cursor))
-  else if (opts?.before) convConditions.push(lt(logsTable.id, opts.before))
+  applyCommonConditions(convConditions, opts)
 
   const convMessages = db
     .select({ id: logsTable.id })
@@ -78,6 +149,14 @@ export function getLogsFromDb(
   // --- Step 2: Fetch all entries within the boundary range ---
   // DB filters by visible=1 only; isVisible() post-filters by entry type.
   const allConditions = [eq(logsTable.issueId, issueId), eq(logsTable.visible, 1)]
+
+  // Apply turnIndex filters to step 2 as well
+  if (opts?.turnIndex != null) {
+    allConditions.push(gte(logsTable.turnIndex, opts.turnIndex))
+  }
+  if (opts?.turnIndexEnd != null) {
+    allConditions.push(lte(logsTable.turnIndex, opts.turnIndexEnd))
+  }
 
   if (opts?.cursor) allConditions.push(gt(logsTable.id, opts.cursor))
   else if (opts?.before) allConditions.push(lt(logsTable.id, opts.before))
@@ -103,52 +182,46 @@ export function getLogsFromDb(
   // Always return in ascending (chronological) order
   if (isReverse) rows.reverse()
 
-  // Batch-fetch tool details for any rows that might be tool-use entries
-  const toolByLogId = new Map<string, (typeof toolsTable)['$inferSelect']>()
-  if (rows.length > 0) {
-    const logIds = rows.map(r => r.id)
-    const toolRows = db.select().from(toolsTable).where(inArray(toolsTable.logId, logIds)).all()
-    for (const r of toolRows) toolByLogId.set(r.logId, r)
-  }
+  const toolByLogId = fetchToolDetails(rows.map(r => r.id))
+  const entries = rows.map(row => rowToEntry(row, toolByLogId)).filter(isVisible)
 
-  const entries = rows
-    .map((row) => {
-      const parsedMeta = row.metadata ? JSON.parse(row.metadata) : undefined
-      const base: NormalizedLogEntry = {
-        messageId: row.id,
-        replyToMessageId: row.replyToMessageId ?? undefined,
-        entryType: row.entryType as NormalizedLogEntry['entryType'],
-        content: row.content.trim(),
-        turnIndex: row.turnIndex,
-        timestamp: row.timestamp ?? undefined,
-        metadata: parsedMeta,
-      }
+  return { entries, hasMore }
+}
 
-      // Attach tool detail and reconstruct toolAction + content/metadata from tools table
-      const tool = toolByLogId.get(row.id)
-      if (tool) {
-        const rawData = tool.raw ? JSON.parse(tool.raw) : {}
-        base.toolDetail = {
-          kind: tool.kind,
-          toolName: tool.toolName,
-          toolCallId: tool.toolCallId ?? undefined,
-          isResult: tool.isResult ?? false,
-          raw: rawData,
-        }
-        base.toolAction = rawToToolAction(tool.kind, rawData)
-        // Restore content & metadata from raw for legacy rows where
-        // tool-use content was not stored in issues_logs (pre-fix).
-        if (!base.content && rawData.content) {
-          base.content = rawData.content as string
-        }
-        if (!base.metadata && rawData.metadata) {
-          base.metadata = rawData.metadata as Record<string, unknown>
-        }
-      }
+/**
+ * Single-pass query for filtered entry types.
+ * Both pagination and results are scoped to the requested types only.
+ */
+function getFilteredLogsFromDb(
+  issueId: string,
+  opts: LogQueryOpts,
+): PaginatedLogResult {
+  const isReverse = !opts.cursor
+  const effectiveLimit = opts.limit ?? MAX_LOG_ENTRIES
 
-      return base
-    })
-    .filter(isVisible)
+  const conditions = [
+    eq(logsTable.issueId, issueId),
+    eq(logsTable.visible, 1),
+    inArray(logsTable.entryType, opts.entryTypes!),
+  ]
+  applyCommonConditions(conditions, opts)
+
+  const rows = db
+    .select()
+    .from(logsTable)
+    .where(and(...conditions))
+    .orderBy(isReverse ? desc(logsTable.id) : asc(logsTable.id))
+    .limit(effectiveLimit + 1)
+    .all()
+
+  const hasMore = rows.length > effectiveLimit
+  if (hasMore) rows.pop()
+
+  // Always return in ascending (chronological) order
+  if (isReverse) rows.reverse()
+
+  const toolByLogId = fetchToolDetails(rows.map(r => r.id))
+  const entries = rows.map(row => rowToEntry(row, toolByLogId)).filter(isVisible)
 
   return { entries, hasMore }
 }

--- a/apps/api/src/engines/issue/queries.ts
+++ b/apps/api/src/engines/issue/queries.ts
@@ -3,7 +3,7 @@ import { cacheDel } from '@/cache'
 import { getAppSetting, setAppSetting } from '@/db/helpers'
 import type { EngineType } from '@/engines/types'
 import type { EngineContext } from './context'
-import type { PaginatedLogResult } from './persistence/queries'
+import type { LogQueryOpts, PaginatedLogResult } from './persistence/queries'
 import { getLogsFromDb } from './persistence/queries'
 import { cancel } from './process/cancel'
 import { getActiveProcesses, getActiveProcessForIssue } from './process/state'
@@ -124,11 +124,7 @@ export async function migrateSlashCommandsKey(): Promise<void> {
 export function getLogs(
   ctx: EngineContext,
   issueId: string,
-  opts?: {
-    cursor?: string // ULID id — fetch entries after this
-    before?: string // ULID id — fetch entries before this
-    limit?: number
-  },
+  opts?: LogQueryOpts,
 ): PaginatedLogResult {
   // DB filters by visible=1; isVisible() post-filters by entry type.
   const result = getLogsFromDb(issueId, opts)
@@ -165,9 +161,19 @@ export function getLogs(
   const newestDbId = persisted.length > 0 ? persisted.at(-1).messageId : undefined
   const lowerBound = opts?.cursor ?? newestDbId
 
+  // Build in-memory filter set to match DB-level entryTypes / turnIndex filters
+  const entryTypeSet = opts?.entryTypes ? new Set(opts.entryTypes) : undefined
+  const turnLower = opts?.turnIndex
+  const turnUpper = opts?.turnIndexEnd
+
   const merged = [...persisted]
   for (const entry of active.logs.toArray()) {
     if (!isVisible(entry)) continue
+    // Apply entryTypes filter
+    if (entryTypeSet && !entryTypeSet.has(entry.entryType)) continue
+    // Apply turnIndex range filter
+    if (turnLower != null && (entry.turnIndex == null || entry.turnIndex < turnLower)) continue
+    if (turnUpper != null && (entry.turnIndex == null || entry.turnIndex > turnUpper)) continue
     const key = entry.messageId ?
       `id:${entry.messageId}` :
       `${entry.turnIndex ?? 0}:${entry.timestamp ?? ''}:${entry.entryType}:${entry.content}`

--- a/apps/api/src/routes/issues/logs.ts
+++ b/apps/api/src/routes/issues/logs.ts
@@ -1,26 +1,123 @@
+import type { Context } from 'hono'
 import { Hono } from 'hono'
 import { findProject, getAppSetting } from '@/db/helpers'
 import { issueEngine } from '@/engines/issue'
 import { DEFAULT_LOG_PAGE_SIZE, LOG_PAGE_SIZE_KEY } from '@/engines/issue/constants'
+import type { LogQueryOpts } from '@/engines/issue/persistence/queries'
 import { getProjectOwnedIssue, serializeIssue } from './_shared'
 
-const logs = new Hono()
+/** Allowed entry types that callers can filter by. */
+const VALID_ENTRY_TYPES = new Set([
+  'user-message',
+  'assistant-message',
+  'tool-use',
+  'system-message',
+  'error-message',
+  'thinking',
+])
 
-// GET /api/projects/:projectId/issues/:id/logs — Get logs
-logs.get('/:id/logs', async (c) => {
-  const projectId = c.req.param('projectId')!
-  const project = await findProject(projectId)
-  if (!project) {
-    return c.json({ success: false, error: 'Project not found' }, 404)
+/** Allowed filter keys in the path. */
+const VALID_FILTER_KEYS = new Set(['types', 'turn'])
+
+/** Parse comma-separated entry types, return valid list or error string. */
+function parseEntryTypes(raw: string): { types: string[] } | { error: string } {
+  const requested = raw.split(',').map(s => s.trim()).filter(Boolean)
+  const valid = requested.filter(t => VALID_ENTRY_TYPES.has(t))
+  if (valid.length === 0) {
+    return { error: `Invalid types. Allowed: ${[...VALID_ENTRY_TYPES].join(', ')}` }
+  }
+  return { types: valid }
+}
+
+/**
+ * Parse turn value into a range { start, end }.
+ *
+ * Supported formats:
+ *   "3"       → turn 3 only
+ *   "2-5"     → turns 2 through 5
+ *   "last"    → last turn only
+ *   "last3"   → last 3 turns
+ */
+function parseTurn(raw: string, issueId: string): { start: number, end: number } | { error: string } {
+  const maxTurn = issueEngine.getMaxTurnIndex(issueId)
+  if (maxTurn < 0) {
+    return { error: 'No turns exist for this issue' }
   }
 
-  const issueId = c.req.param('id')!
-  const issue = await getProjectOwnedIssue(project.id, issueId)
-  if (!issue) {
-    return c.json({ success: false, error: 'Issue not found' }, 404)
+  // "last" or "lastN" → last N turns (default N=1)
+  const lastN = raw.match(/^last(\d+)?$/)
+  if (lastN) {
+    const n = lastN[1] ? Number(lastN[1]) : 1
+    if (n <= 0) return { error: 'lastN must be a positive number' }
+    return { start: Math.max(0, maxTurn - n + 1), end: maxTurn }
   }
 
-  // Cursor params are now opaque ULID strings (no parsing needed)
+  // "X-Y" → range
+  const range = raw.match(/^(\d+)-(\d+)$/)
+  if (range) {
+    const start = Number(range[1])
+    const end = Number(range[2])
+    if (start > end) return { error: 'turn range start must be <= end' }
+    return { start, end }
+  }
+
+  // single number
+  const n = Math.floor(Number(raw))
+  if (Number.isNaN(n) || n < 0) {
+    return { error: 'turn must be a number, range (2-5), "last", or "lastN" (e.g. last3)' }
+  }
+  return { start: n, end: n }
+}
+
+/**
+ * Parse filter path segments into a key-value map.
+ * Path like "types/user-message,assistant-message/turn/last" becomes:
+ *   { types: "user-message,assistant-message", turn: "last" }
+ */
+function parseFilterPath(raw: string): { filters: Record<string, string> } | { error: string } {
+  const segments = raw.split('/').filter(Boolean)
+  if (segments.length % 2 !== 0) {
+    return { error: 'Filter path must be key/value pairs (e.g. /filter/types/user-message/turn/latest)' }
+  }
+  const filters: Record<string, string> = {}
+  for (let i = 0; i < segments.length; i += 2) {
+    const key = segments[i]
+    const value = segments[i + 1]
+    if (!VALID_FILTER_KEYS.has(key)) {
+      return { error: `Unknown filter key "${key}". Allowed: ${[...VALID_FILTER_KEYS].join(', ')}` }
+    }
+    if (key in filters) {
+      return { error: `Duplicate filter key "${key}"` }
+    }
+    filters[key] = decodeURIComponent(value)
+  }
+  return { filters }
+}
+
+/** Build LogQueryOpts from parsed filter map. */
+function buildFilterOpts(filters: Record<string, string>, issueId: string): { opts: Partial<LogQueryOpts> } | { error: string } {
+  const opts: Partial<LogQueryOpts> = {}
+
+  if (filters.types) {
+    const parsed = parseEntryTypes(filters.types)
+    if ('error' in parsed) return parsed
+    opts.entryTypes = parsed.types
+  }
+
+  if (filters.turn) {
+    const parsed = parseTurn(filters.turn, issueId)
+    if ('error' in parsed) return parsed
+
+    // Turn range always sets turnIndex bounds
+    opts.turnIndex = parsed.start
+    opts.turnIndexEnd = parsed.end
+  }
+
+  return { opts }
+}
+
+/** Parse pagination query params. */
+async function parsePagination(c: Context) {
   const cursor = c.req.query('cursor') || undefined
   const before = c.req.query('before') || undefined
   const limitParam = c.req.query('limit')
@@ -33,30 +130,78 @@ logs.get('/:id/logs', async (c) => {
     limit = pageSizeRaw ? Number(pageSizeRaw) || DEFAULT_LOG_PAGE_SIZE : DEFAULT_LOG_PAGE_SIZE
   }
 
-  // Pagination now counts only conversation messages (user + assistant)
-  // but returns all visible entries within the range.
-  const result = issueEngine.getLogs(issueId, {
-    cursor,
-    before,
-    limit,
-  })
+  return { cursor, before, limit }
+}
 
-  const isReverse = !cursor
-
-  // nextCursor: use ULID messageId directly.
-  // For reverse → oldest entry in batch (first) so client passes as `before`.
-  // For forward → newest entry (last) for next newer page via `cursor`.
+/** Execute log query and return JSON response. */
+function queryAndRespond(c: Context, issue: Awaited<ReturnType<typeof getProjectOwnedIssue>>, issueId: string, opts: LogQueryOpts) {
+  const result = issueEngine.getLogs(issueId, opts)
+  const isReverse = !opts.cursor
   const cursorEntry = isReverse ? result.entries[0] : result.entries.at(-1)
   const nextCursor = result.hasMore && cursorEntry?.messageId ? cursorEntry.messageId : null
 
   return c.json({
     success: true,
     data: {
-      issue: serializeIssue(issue),
+      issue: serializeIssue(issue!),
       logs: result.entries,
       nextCursor,
       hasMore: result.hasMore,
     },
+  })
+}
+
+/** Validate project + issue ownership, return both or error response. */
+async function resolveIssue(c: Context) {
+  const projectId = c.req.param('projectId')!
+  const project = await findProject(projectId)
+  if (!project) {
+    return { error: c.json({ success: false, error: 'Project not found' }, 404) }
+  }
+  const issueId = c.req.param('id')!
+  const issue = await getProjectOwnedIssue(project.id, issueId)
+  if (!issue) {
+    return { error: c.json({ success: false, error: 'Issue not found' }, 404) }
+  }
+  return { issue, issueId }
+}
+
+const logs = new Hono()
+
+// GET /:id/logs — All logs (default)
+logs.get('/:id/logs', async (c) => {
+  const resolved = await resolveIssue(c)
+  if ('error' in resolved) return resolved.error
+  const pagination = await parsePagination(c)
+  return queryAndRespond(c, resolved.issue, resolved.issueId, pagination)
+})
+
+// GET /:id/logs/filter/* — Filtered logs with path-based key/value pairs
+logs.get('/:id/logs/filter/*', async (c) => {
+  const resolved = await resolveIssue(c)
+  if ('error' in resolved) return resolved.error
+
+  const filterPath = c.req.param('*')
+  if (!filterPath) {
+    // /logs/filter/ with nothing after → return all logs
+    const pagination = await parsePagination(c)
+    return queryAndRespond(c, resolved.issue, resolved.issueId, pagination)
+  }
+
+  const parsed = parseFilterPath(filterPath)
+  if ('error' in parsed) {
+    return c.json({ success: false, error: parsed.error }, 400)
+  }
+
+  const filterOpts = buildFilterOpts(parsed.filters, resolved.issueId)
+  if ('error' in filterOpts) {
+    return c.json({ success: false, error: filterOpts.error }, 400)
+  }
+
+  const pagination = await parsePagination(c)
+  return queryAndRespond(c, resolved.issue, resolved.issueId, {
+    ...pagination,
+    ...filterOpts.opts,
   })
 })
 

--- a/apps/api/src/routes/issues/logs.ts
+++ b/apps/api/src/routes/issues/logs.ts
@@ -12,7 +12,6 @@ const VALID_ENTRY_TYPES = new Set([
   'assistant-message',
   'tool-use',
   'system-message',
-  'error-message',
   'thinking',
 ])
 
@@ -89,7 +88,11 @@ function parseFilterPath(raw: string): { filters: Record<string, string> } | { e
     if (key in filters) {
       return { error: `Duplicate filter key "${key}"` }
     }
-    filters[key] = decodeURIComponent(value)
+    try {
+      filters[key] = decodeURIComponent(value)
+    } catch {
+      return { error: `Malformed percent-encoding in filter value for "${key}"` }
+    }
   }
   return { filters }
 }

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -49,7 +49,7 @@ Database-backed DELETE operations (projects, issues, notes, etc.) use an `isDele
 | [projects.md](./projects.md) | Project CRUD, archive, sort |
 | [issues.md](./issues.md) | Issue CRUD, bulk update |
 | [execution.md](./execution.md) | Execute, follow-up, restart, cancel |
-| [logs.md](./logs.md) | Issue logs (paginated) |
+| [logs.md](./logs.md) | Issue logs (paginated, filtered) |
 | [changes.md](./changes.md) | Git changes and file diffs |
 | [attachments.md](./attachments.md) | File attachments |
 | [engines.md](./engines.md) | Engine discovery, models, settings |

--- a/docs/api/logs.md
+++ b/docs/api/logs.md
@@ -2,7 +2,7 @@
 
 ## GET /api/projects/:projectId/issues/:id/logs
 
-Get paginated issue logs.
+Get paginated issue logs (all types).
 
 | Query Param | Type | Description |
 |---|---|---|
@@ -17,9 +17,53 @@ Get paginated issue logs.
   "success": true,
   "data": {
     "issue": "Issue",
-    "logs": [{ "messageId": "...", "type": "...", "content": "...", "role": "..." }],
+    "logs": [{ "messageId": "...", "entryType": "...", "content": "...", "turnIndex": 0 }],
     "nextCursor": "string | null",
     "hasMore": true
   }
 }
 ```
+
+## GET /api/projects/:projectId/issues/:id/logs/filter/*
+
+Get filtered issue logs. Path segments after `/filter/` are parsed as key/value pairs (order-independent).
+
+### Filter Keys
+
+| Key | Value Format | Description |
+|---|---|---|
+| `types` | Comma-separated | Filter by entry type |
+| `turn` | See below | Filter by turn index |
+
+**Allowed entry types:** `user-message`, `assistant-message`, `tool-use`, `system-message`, `thinking`
+
+**Turn value formats:**
+
+| Format | Example | Description |
+|---|---|---|
+| Single number | `3` | Specific turn |
+| Range | `2-5` | Turns 2 through 5 (inclusive) |
+| `last` | `last` | Most recent turn |
+| `lastN` | `last3` | Last N turns |
+
+### Examples
+
+```
+# Only user and assistant messages
+GET .../logs/filter/types/user-message,assistant-message
+
+# Last turn only
+GET .../logs/filter/turn/last
+
+# Last 3 turns, tool-use entries only
+GET .../logs/filter/turn/last3/types/tool-use
+
+# Turn range with multiple types
+GET .../logs/filter/types/user-message,assistant-message/turn/2-5
+```
+
+### Query Params
+
+Pagination query params (`cursor`, `before`, `limit`) work the same as the base `/logs` endpoint.
+
+**Response:** Same envelope as `/logs`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,6 +97,7 @@ Hardcoded constants — no DB table:
 | `/api/.../issues/:id/cancel`         | POST               | `issues/command.ts`                                       | Cancel active session            |
 | `/api/.../issues/:id/messages`       | POST               | `issues/message.ts`                                       | Queue pending message            |
 | `/api/.../issues/:id/logs`           | GET                | `issues/logs.ts`                                          | Paginated logs (cursor-based)    |
+| `/api/.../issues/:id/logs/filter/*`  | GET                | `issues/logs.ts`                                          | Filtered logs (path key/value)   |
 | `/api/.../issues/:id/attachments`    | GET, POST          | `issues/attachments.ts`                                   | File upload (multipart)          |
 | `/api/.../issues/:id/changes`        | GET                | `issues/changes.ts`                                       | Git diff stats                   |
 | `/api/.../issues/:id/title/generate` | POST               | `issues/title.ts`                                         | AI-generated title               |

--- a/docs/development.md
+++ b/docs/development.md
@@ -154,6 +154,7 @@ POST           /api/projects/:projectId/issues/:id/restart
 POST           /api/projects/:projectId/issues/:id/cancel
 POST           /api/projects/:projectId/issues/:id/messages
 GET            /api/projects/:projectId/issues/:id/logs
+GET            /api/projects/:projectId/issues/:id/logs/filter/*
 GET/POST       /api/projects/:projectId/issues/:id/attachments
 GET            /api/projects/:projectId/issues/:id/changes
 POST           /api/projects/:projectId/issues/:id/auto-title


### PR DESCRIPTION
## Summary

- Add `GET /:id/logs/filter/*` route with flexible path-based key/value filtering
- Support `types` filter (comma-separated: `user-message,assistant-message`) and `turn` filter (`3`, `2-5`, `last`, `last3`)
- Extract shared `rowToEntry()` / `fetchToolDetails()` helpers to eliminate ~35 lines of duplicated row mapping
- Fix missing `isVisible()` post-filter in `getFilteredLogsFromDb`
- Fix `parseTurn` to check in-memory ring buffer via `getMaxTurnIndex()` (prevents false 400 during first in-flight turn)
- Remove dead `orTurnIndex` union logic from `LogQueryOpts`, DB layer, and in-memory merge

## Examples

```
GET /logs                                                    # all logs
GET /logs/filter/types/user-message,assistant-message        # by type
GET /logs/filter/turn/last                                   # last turn
GET /logs/filter/turn/last3                                  # last 3 turns
GET /logs/filter/turn/2-5/types/tool-use                     # combined
```

## Test plan

- [ ] Verify `GET /logs` returns all logs (unchanged behavior)
- [ ] Verify `GET /logs/filter/types/user-message` returns only user messages
- [ ] Verify `GET /logs/filter/types/user-message,assistant-message` returns both types
- [ ] Verify `GET /logs/filter/turn/last` returns last turn entries
- [ ] Verify `GET /logs/filter/turn/last3` returns last 3 turns
- [ ] Verify `GET /logs/filter/turn/2-5` returns range
- [ ] Verify combined filters work (types + turn)
- [ ] Verify `turn=last` works during active first turn (in-memory only)
- [ ] Verify invalid filter keys return 400
- [ ] Verify pagination (cursor/before/limit) works with filters