### PR TITLE
feat: add markdown view button for agent messages

### DIFF
--- a/apps/frontend/src/components/issue-detail/LogEntry.tsx
+++ b/apps/frontend/src/components/issue-detail/LogEntry.tsx
@@ -5,6 +5,7 @@ import {
   Circle,
   Clock,
   Copy,
+  Eye,
   FileEdit,
   FileText,
   Globe,
@@ -15,12 +16,21 @@ import {
   Terminal,
   Wrench,
 } from 'lucide-react'
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { getCommandPreview } from '@/lib/command-preview'
 import { formatFileSize } from '@/lib/format'
 import type { NormalizedLogEntry, ToolAction } from '@/types/kanban'
 import { MarkdownContent } from './MarkdownContent'
+
+const MarkdownRenderer = lazy(() =>
+  import('@/components/files/MarkdownRenderer').then(m => ({ default: m.MarkdownRenderer })),
+)
 
 interface AttachmentMeta {
   id: string
@@ -411,6 +421,7 @@ function AssistantMessage({
 }) {
   const { t } = useTranslation()
   const [copied, setCopied] = useState(false)
+  const [viewOpen, setViewOpen] = useState(false)
 
   const handleCopy = () => {
     navigator.clipboard
@@ -425,22 +436,40 @@ function AssistantMessage({
   return (
     <div className="group py-1.5 animate-message-enter">
       <div className="relative min-w-0">
-        <button
-          type="button"
-          onClick={handleCopy}
-          className="absolute right-0 top-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150 rounded-md p-1 text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/50 z-10"
-          title={t('session.copyMessage')}
-        >
-          {copied ?
-              (
-                <Check className="h-3.5 w-3.5 text-emerald-500" />
-              ) :
-              (
-                <Copy className="h-3.5 w-3.5" />
-              )}
-        </button>
+        <div className="absolute right-0 top-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-150 z-10">
+          <button
+            type="button"
+            onClick={() => setViewOpen(true)}
+            className="rounded-md p-1 text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/50"
+            title={t('session.viewMessage')}
+          >
+            <Eye className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="rounded-md p-1 text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/50"
+            title={t('session.copyMessage')}
+          >
+            {copied ?
+                (
+                  <Check className="h-3.5 w-3.5 text-emerald-500" />
+                ) :
+                (
+                  <Copy className="h-3.5 w-3.5" />
+                )}
+          </button>
+        </div>
         <MarkdownContent content={content} className="text-[14px] leading-[1.75]" />
       </div>
+      <Dialog open={viewOpen} onOpenChange={setViewOpen}>
+        <DialogContent className="sm:max-w-3xl max-h-[80vh] overflow-y-auto">
+          <DialogTitle className="sr-only">{t('session.viewMessage')}</DialogTitle>
+          <Suspense fallback={<div className="p-4 text-sm text-muted-foreground">Loading...</div>}>
+            <MarkdownRenderer content={content} />
+          </Suspense>
+        </DialogContent>
+      </Dialog>
       <div className="flex items-center gap-2 mt-1">
         {timestamp ?
             (

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -215,6 +215,7 @@
     "executionFailed": "Execution failed",
     "duration": "Completed in {{time}}",
     "copyMessage": "Copy message",
+    "viewMessage": "View as Markdown",
     "status": {
       "pending": "Pending",
       "spawning": "Spawning",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -215,6 +215,7 @@
     "executionFailed": "执行失败",
     "duration": "耗时 {{time}}",
     "copyMessage": "复制消息",
+    "viewMessage": "查看 Markdown 渲染",
     "status": {
       "pending": "等待中",
       "spawning": "启动中",


### PR DESCRIPTION
## Summary
- Add "View" (eye icon) button next to the copy button on assistant messages
- Clicking opens a dialog that renders the message as properly formatted markdown (headings, lists, code blocks, tables, etc.) using `react-markdown` + `remark-gfm`
- `MarkdownRenderer` is lazy-loaded via `React.lazy()` to avoid impacting initial bundle size

## Test plan
- [ ] Hover over an assistant message and verify both View and Copy buttons appear
- [ ] Click the eye icon and verify the dialog opens with properly rendered markdown
- [ ] Verify code blocks, tables, headings, and lists render correctly in the dialog
- [ ] Verify the dialog can be closed via the X button or clicking outside
- [ ] Verify the copy button still works as before