### PR TITLE
fix: pass model args as separate tokens to avoid shell glob issues

### DIFF
--- a/apps/api/src/engines/command.ts
+++ b/apps/api/src/engines/command.ts
@@ -51,10 +51,9 @@ export class CommandBuilder {
   }
 
   param(key: string, value?: string): this {
+    this.args.push(key)
     if (value !== undefined) {
-      this.args.push(`${key}=${value}`)
-    } else {
-      this.args.push(key)
+      this.args.push(value)
     }
     return this
   }


### PR DESCRIPTION
## Summary

- Split `--model=value` into `--model` and `value` as separate array elements in `CommandBuilder.param()`
- Model names like `claude-opus-4-6[1m]` contain brackets that are interpreted as glob patterns by shells
- Using separate args is safer and more conventional for spawn-based process invocation

## Test plan

- [ ] Execute an issue with a model containing brackets (e.g. `claude-opus-4-6[1m]`) and verify the process spawns correctly
- [ ] Verify existing engine executions still work as expected