### PR TITLE
feat: split ACP into per-agent engines with model toggle

### DIFF
--- a/apps/api/src/db/helpers.ts
+++ b/apps/api/src/db/helpers.ts
@@ -131,6 +131,46 @@ export async function getAllEngineDefaultModels(): Promise<Record<string, string
   })
 }
 
+// --- Hidden Models persistence ---
+
+export async function getEngineHiddenModels(engineType: string): Promise<string[]> {
+  const raw = await getAppSetting(`engine:${engineType}:hiddenModels`)
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+export async function setEngineHiddenModels(engineType: string, modelIds: string[]): Promise<void> {
+  await setAppSetting(`engine:${engineType}:hiddenModels`, JSON.stringify(modelIds))
+  await cacheDel('engineHiddenModels:all')
+}
+
+export async function getAllEngineHiddenModels(): Promise<Record<string, string[]>> {
+  return cacheGetOrSet('engineHiddenModels:all', SETTINGS_CACHE_TTL, async () => {
+    const rows = await db
+      .select({ key: appSettingsTable.key, value: appSettingsTable.value })
+      .from(appSettingsTable)
+      .where(sql`${appSettingsTable.key} LIKE 'engine:%:hiddenModels'`)
+    const result: Record<string, string[]> = {}
+    const prefix = 'engine:'
+    const suffix = ':hiddenModels'
+    for (const row of rows) {
+      const engineType = row.key.slice(prefix.length, -suffix.length)
+      try {
+        const parsed = JSON.parse(row.value)
+        if (Array.isArray(parsed)) result[engineType] = parsed
+      } catch {
+        // skip invalid entries
+      }
+    }
+    return result
+  })
+}
+
 // --- Probe Results persistence ---
 
 interface ProbeData {

--- a/apps/api/src/db/helpers.ts
+++ b/apps/api/src/db/helpers.ts
@@ -147,6 +147,15 @@ export async function getEngineHiddenModels(engineType: string): Promise<string[
 export async function setEngineHiddenModels(engineType: string, modelIds: string[]): Promise<void> {
   await setAppSetting(`engine:${engineType}:hiddenModels`, JSON.stringify(modelIds))
   await cacheDel('engineHiddenModels:all')
+
+  // If the current default model is now hidden, clear it so the engine uses its own default
+  if (modelIds.length > 0) {
+    const currentDefault = await getAppSetting(`engine:${engineType}:defaultModel`)
+    if (currentDefault && modelIds.includes(currentDefault)) {
+      await deleteAppSetting(`engine:${engineType}:defaultModel`)
+      await cacheDel('engineDefaultModels:all')
+    }
+  }
 }
 
 export async function getAllEngineHiddenModels(): Promise<Record<string, string[]>> {

--- a/apps/api/src/engines/executors/acp/agents/base.ts
+++ b/apps/api/src/engines/executors/acp/agents/base.ts
@@ -96,7 +96,7 @@ export function parseAcpModelWithRegistry(
   model: string | null | undefined,
   registry: Record<AcpAgentId, AcpAgentDefinition>,
 ): ParsedAcpModel | null {
-  if (!model) return null
+  if (!model || model === 'auto') return null
 
   if (!model.startsWith(ACP_MODEL_PREFIX)) {
     return {

--- a/apps/api/src/engines/executors/acp/agents/claude.ts
+++ b/apps/api/src/engines/executors/acp/agents/claude.ts
@@ -19,8 +19,9 @@ function getClaudeAuthStatus(): EngineAvailability['authStatus'] {
 export const claudeAgent: AcpAgentDefinition = {
   id: 'claude',
   label: 'Claude',
-  commandName: 'claude-code-acp',
-  npxFallback: ['npx', '-y', '@zed-industries/claude-code-acp@latest'],
+  // Renamed from claude-code-acp to claude-agent-acp (old package is deprecated)
+  commandName: 'claude-agent-acp',
+  npxFallback: ['npx', '-y', '@zed-industries/claude-agent-acp@latest'],
   acpArgs: [],
   authStatus: getClaudeAuthStatus,
   verify: async (cmd) => {

--- a/apps/api/src/engines/executors/acp/executor.ts
+++ b/apps/api/src/engines/executors/acp/executor.ts
@@ -14,6 +14,7 @@ import {
   normalizeAcpEvent,
   spawnAcpProcess,
 } from './acp-client'
+import type { AcpAgentId } from './agents'
 import {
   getAcpAgentAvailability,
   getAcpAgents,
@@ -27,10 +28,18 @@ export class AcpExecutor implements EngineExecutor {
   readonly protocol = 'acp' as const
   readonly capabilities: EngineCapability[] = ['session-fork']
 
+  /** Resolve agent ID: model string takes precedence, then SpawnOptions.agent, then 'gemini'. */
+  private resolveAgentId(model: string | undefined, agent: string | undefined): AcpAgentId {
+    const parsedModel = parseAcpModel(model)
+    if (parsedModel) return parsedModel.agentId
+    return (agent as AcpAgentId) ?? 'gemini'
+  }
+
   async spawn(options: SpawnOptions, env: ExecutionEnv): Promise<SpawnedProcess> {
     const parsedModel = parseAcpModel(options.model)
+    const agentId = this.resolveAgentId(options.model, options.agent)
     return spawnAcpProcess({
-      cmd: getAcpLaunchCommand(parsedModel?.agentId ?? 'gemini'),
+      cmd: getAcpLaunchCommand(agentId),
       workingDir: options.workingDir,
       prompt: options.prompt,
       permissionMode: options.permissionMode ?? 'auto',
@@ -44,8 +53,9 @@ export class AcpExecutor implements EngineExecutor {
 
   async spawnFollowUp(options: FollowUpOptions, env: ExecutionEnv): Promise<SpawnedProcess> {
     const parsedModel = parseAcpModel(options.model)
+    const agentId = this.resolveAgentId(options.model, options.agent)
     return spawnAcpProcess({
-      cmd: getAcpLaunchCommand(parsedModel?.agentId ?? 'gemini'),
+      cmd: getAcpLaunchCommand(agentId),
       workingDir: options.workingDir,
       prompt: options.prompt,
       permissionMode: options.permissionMode ?? 'auto',

--- a/apps/api/src/engines/executors/codex/executor.ts
+++ b/apps/api/src/engines/executors/codex/executor.ts
@@ -296,8 +296,10 @@ async function queryCodexModels(): Promise<EngineModel[]> {
  * Build the common thread start params used by both spawn and spawnFollowUp.
  */
 function buildThreadParams(options: SpawnOptions): ThreadStartParams {
+  // Treat 'auto' as unset so Codex uses its own default model
+  const model = options.model && options.model !== 'auto' ? options.model : undefined
   const params: ThreadStartParams = {
-    model: options.model,
+    model,
     cwd: options.workingDir,
     approvalPolicy: 'never',
     sandbox: 'danger-full-access',

--- a/apps/api/src/engines/executors/index.ts
+++ b/apps/api/src/engines/executors/index.ts
@@ -8,13 +8,11 @@ import type {
 import { AcpExecutor } from './acp'
 import { ClaudeCodeExecutor } from './claude'
 import { CodexExecutor } from './codex'
-import { EchoExecutor } from './echo'
 
 // Re-export executor classes
 export { AcpExecutor } from './acp'
 export { ClaudeCodeExecutor } from './claude'
 export { CodexExecutor } from './codex'
-export { EchoExecutor } from './echo'
 
 /**
  * Default engine registry — manages all executor instances.
@@ -27,7 +25,16 @@ class DefaultEngineRegistry implements EngineRegistry {
   }
 
   get(engineType: EngineType): EngineExecutor | undefined {
-    return this.executors.get(engineType)
+    // Direct match first
+    const direct = this.executors.get(engineType)
+    if (direct) return direct
+
+    // Virtual ACP engine types (e.g. "acp:codex") resolve to the ACP executor
+    if (engineType.startsWith('acp:')) {
+      return this.executors.get('acp' as EngineType)
+    }
+
+    return undefined
   }
 
   getAll(): EngineExecutor[] {
@@ -56,7 +63,6 @@ function createRegistry(): EngineRegistry {
   registry.register(new ClaudeCodeExecutor())
   registry.register(new CodexExecutor())
   registry.register(new AcpExecutor())
-  registry.register(new EchoExecutor())
 
   return registry
 }

--- a/apps/api/src/engines/executors/index.ts
+++ b/apps/api/src/engines/executors/index.ts
@@ -47,7 +47,9 @@ class DefaultEngineRegistry implements EngineRegistry {
   }
 
   async getModels(engineType: EngineType): Promise<EngineModel[]> {
-    const executor = this.executors.get(engineType)
+    // Resolve virtual ACP types to base 'acp' executor
+    const lookupType = engineType.startsWith('acp:') ? ('acp' as EngineType) : engineType
+    const executor = this.executors.get(lookupType)
     if (!executor) return []
     return executor.getModels()
   }

--- a/apps/api/src/engines/issue/lifecycle/spawn.ts
+++ b/apps/api/src/engines/issue/lifecycle/spawn.ts
@@ -24,6 +24,7 @@ import {
   isWorktreeRegistered,
   resolveWorktreePath,
 } from '@/engines/issue/utils/worktree'
+import { parseAcpEngineType } from '@/engines/startup-probe'
 import type { EngineType, PermissionPolicy, SpawnedProcess } from '@/engines/types'
 import { logger } from '@/logger'
 import { monitorCompletion } from './completion-monitor'
@@ -46,6 +47,7 @@ export async function spawnWithSessionFallback(
     projectId: string
     envVars?: Record<string, string>
     systemPrompt?: string
+    agent?: string
   },
 ): Promise<SpawnedProcess> {
   const spawnCtx = {
@@ -62,6 +64,7 @@ export async function spawnWithSessionFallback(
         sessionId: opts.sessionId,
         model: opts.model,
         permissionMode: opts.permissionMode,
+        agent: opts.agent,
       },
       spawnCtx,
     )
@@ -91,6 +94,7 @@ export async function spawnWithSessionFallback(
         model: opts.model,
         permissionMode: opts.permissionMode,
         externalSessionId,
+        agent: opts.agent,
       },
       spawnCtx,
     )
@@ -116,6 +120,7 @@ export async function spawnFresh(
     permissionMode: PermissionPolicy
     projectId: string
     envVars?: Record<string, string>
+    agent?: string
   },
 ): Promise<SpawnedProcess> {
   const externalSessionId = crypto.randomUUID()
@@ -126,6 +131,7 @@ export async function spawnFresh(
       model: opts.model,
       permissionMode: opts.permissionMode,
       externalSessionId,
+      agent: opts.agent,
     },
     {
       vars: opts.envVars ?? {},
@@ -189,6 +195,7 @@ export async function spawnRetry(
   const permOptions = getPermissionOptions(engineType)
   const executionId = crypto.randomUUID()
   const projCtx = await getProjectExecContext(issue.projectId)
+  const acpAgent = parseAcpEngineType(engineType) ?? undefined
 
   const spawnOpts = {
     workingDir,
@@ -198,6 +205,7 @@ export async function spawnRetry(
     projectId: issue.projectId,
     envVars: projCtx.envVars,
     systemPrompt: projCtx.systemPrompt,
+    agent: acpAgent,
   }
   const spawned = issue.sessionFields.externalSessionId ?
       await spawnWithSessionFallback(executor, issueId, {
@@ -312,6 +320,7 @@ export async function spawnFollowUpProcess(
 
   const permOptions = getPermissionOptions(engineType, permissionMode)
   const projCtx = await getProjectExecContext(issue.projectId)
+  const acpAgent = parseAcpEngineType(engineType) ?? undefined
 
   let spawned: SpawnedProcess
   try {
@@ -324,6 +333,7 @@ export async function spawnFollowUpProcess(
       projectId: issue.projectId,
       envVars: projCtx.envVars,
       systemPrompt: projCtx.systemPrompt,
+      agent: acpAgent,
     })
   } catch (spawnError) {
     // Spawn failed after we already emitted 'running' and persisted the user

--- a/apps/api/src/engines/issue/lifecycle/spawn.ts
+++ b/apps/api/src/engines/issue/lifecycle/spawn.ts
@@ -200,7 +200,7 @@ export async function spawnRetry(
   const spawnOpts = {
     workingDir,
     prompt: issue.sessionFields.prompt ?? '',
-    model: issue.sessionFields.model ?? undefined,
+    model: issue.sessionFields.model === 'auto' ? undefined : (issue.sessionFields.model ?? undefined),
     permissionMode: permOptions.permissionMode,
     projectId: issue.projectId,
     envVars: projCtx.envVars,
@@ -269,7 +269,9 @@ export async function spawnFollowUpProcess(
   }
 
   const executionId = crypto.randomUUID()
-  const effectiveModel = model ?? issue.sessionFields.model ?? undefined
+  // Treat 'auto' as unset — let the engine use its own default
+  const rawModel = model ?? issue.sessionFields.model ?? undefined
+  const effectiveModel = rawModel === 'auto' ? undefined : rawModel
 
   await updateIssueSession(issueId, { sessionStatus: 'running' })
 

--- a/apps/api/src/engines/issue/orchestration/execute.ts
+++ b/apps/api/src/engines/issue/orchestration/execute.ts
@@ -14,6 +14,7 @@ import { getPermissionOptions } from '@/engines/issue/utils/helpers'
 import { createLogNormalizer } from '@/engines/issue/utils/normalizer'
 import { getPidFromSubprocess } from '@/engines/issue/utils/pid'
 import { createWorktree } from '@/engines/issue/utils/worktree'
+import { parseAcpEngineType } from '@/engines/startup-probe'
 import type { EngineType, PermissionPolicy, SpawnedProcess } from '@/engines/types'
 import { logger } from '@/logger'
 import { ROOT_DIR } from '@/root'
@@ -83,6 +84,10 @@ export async function executeIssue(
     const externalSessionId = crypto.randomUUID()
     const executionId = crypto.randomUUID()
 
+    // For virtual ACP engine types (e.g. "acp:claude"), pass the agent ID
+    // so the executor knows which agent binary to spawn even when model is empty.
+    const acpAgent = parseAcpEngineType(opts.engineType) ?? undefined
+
     let spawned: SpawnedProcess
     try {
       spawned = await executor.spawn(
@@ -92,6 +97,7 @@ export async function executeIssue(
           model,
           permissionMode: permOptions.permissionMode,
           externalSessionId,
+          agent: acpAgent,
         },
         {
           vars: opts.envVars ?? {},

--- a/apps/api/src/engines/issue/orchestration/execute.ts
+++ b/apps/api/src/engines/issue/orchestration/execute.ts
@@ -54,10 +54,11 @@ export async function executeIssue(
       throw new Error(`Engine '${opts.engineType}' is not yet executable (spawn not implemented)`)
     }
 
-    let model = opts.model
+    // Treat 'auto' as unset — let the engine use its own default
+    let model = opts.model === 'auto' ? undefined : opts.model
     if (!model) {
       const defaultModel = await getEngineDefaultModel(opts.engineType)
-      if (defaultModel) model = defaultModel
+      if (defaultModel && defaultModel !== 'auto') model = defaultModel
     }
 
     await updateIssueSession(issueId, {

--- a/apps/api/src/engines/issue/orchestration/execute.ts
+++ b/apps/api/src/engines/issue/orchestration/execute.ts
@@ -1,4 +1,3 @@
-import { getEngineDefaultModel } from '@/db/helpers'
 import { getIssueWithSession, updateIssueSession } from '@/engines/engine-store'
 import { engineRegistry } from '@/engines/executors'
 import type { EngineContext } from '@/engines/issue/context'
@@ -54,18 +53,15 @@ export async function executeIssue(
       throw new Error(`Engine '${opts.engineType}' is not yet executable (spawn not implemented)`)
     }
 
-    // Treat 'auto' as unset — let the engine use its own default
-    let model = opts.model === 'auto' ? undefined : opts.model
-    if (!model) {
-      const defaultModel = await getEngineDefaultModel(opts.engineType)
-      if (defaultModel && defaultModel !== 'auto') model = defaultModel
-    }
+    // Treat 'auto' as unset — let the engine CLI use its own default.
+    // Do NOT look up or fill in a default model from DB; the engine decides.
+    const model = opts.model === 'auto' ? undefined : opts.model
 
     await updateIssueSession(issueId, {
       engineType: opts.engineType,
       sessionStatus: 'running',
       prompt: opts.prompt,
-      model,
+      model: model ?? null,
     })
 
     const baseDir = opts.workingDir ?? ROOT_DIR

--- a/apps/api/src/engines/issue/orchestration/restart.ts
+++ b/apps/api/src/engines/issue/orchestration/restart.ts
@@ -18,6 +18,7 @@ import {
 } from '@/engines/issue/utils/helpers'
 import { createLogNormalizer } from '@/engines/issue/utils/normalizer'
 import { createWorktree } from '@/engines/issue/utils/worktree'
+import { parseAcpEngineType } from '@/engines/startup-probe'
 import type { SpawnedProcess } from '@/engines/types'
 import { logger } from '@/logger'
 
@@ -69,13 +70,21 @@ export async function restartIssue(
         (issue.sessionFields.prompt ?? '')
     const effectivePrompt = basePrompt
 
+    // Treat 'auto' as unset — let the engine CLI use its own default
+    const rawModel = issue.sessionFields.model ?? undefined
+    const effectiveModel = rawModel === 'auto' ? undefined : rawModel
+
+    // For virtual ACP engine types (e.g. "acp:claude"), pass the agent ID
+    const acpAgent = parseAcpEngineType(engineType) ?? undefined
+
     const spawnOpts = {
       workingDir,
       prompt: effectivePrompt,
-      model: issue.sessionFields.model ?? undefined,
+      model: effectiveModel,
       permissionMode: permOptions.permissionMode,
       projectId: issue.projectId,
       envVars: projCtx.envVars,
+      agent: acpAgent,
     }
     let spawned: SpawnedProcess
     try {
@@ -87,6 +96,7 @@ export async function restartIssue(
               sessionId: issue.sessionFields.externalSessionId,
               model: spawnOpts.model,
               permissionMode: spawnOpts.permissionMode,
+              agent: acpAgent,
             },
             {
               vars: projCtx.envVars ?? {},

--- a/apps/api/src/engines/issue/queries.ts
+++ b/apps/api/src/engines/issue/queries.ts
@@ -19,7 +19,7 @@ const EMPTY_CATEGORIZED: CategorizedCommands = {
 }
 
 /** All known engine types for cache loading. */
-const ALL_ENGINE_TYPES: EngineType[] = ['claude-code', 'codex', 'acp', 'echo']
+const ALL_ENGINE_TYPES: EngineType[] = ['claude-code', 'codex', 'acp']
 
 /** Per-engine in-memory cache for categorized commands from DB. */
 const cachedCommands = new Map<EngineType, CategorizedCommands>()

--- a/apps/api/src/engines/startup-probe.ts
+++ b/apps/api/src/engines/startup-probe.ts
@@ -3,6 +3,8 @@ import { getProbeResults, saveProbeResults, setAppSetting } from '@/db/helpers'
 import { refreshSlashCommandsCacheForEngine, slashCommandsKey } from '@/engines/issue/queries'
 import { logger } from '@/logger'
 import { ClaudeCodeExecutor, engineRegistry } from './executors'
+import type { AcpAgentId } from './executors/acp/agents'
+import { getAcpAgents } from './executors/acp/agents'
 import type { EngineAvailability, EngineModel, EngineType } from './types'
 
 // Cache keys
@@ -203,6 +205,90 @@ async function discoverSlashCommands(installed: EngineAvailability[]): Promise<v
   }
 }
 
+// ---------- ACP expansion ----------
+
+/** ACP agent prefix for virtual engine types (e.g. "acp:gemini") */
+export const ACP_ENGINE_PREFIX = 'acp:'
+
+/** Build a virtual engine type key for an ACP agent */
+export function toAcpEngineType(agentId: AcpAgentId): string {
+  return `${ACP_ENGINE_PREFIX}${agentId}`
+}
+
+/** Check if an engine type is a virtual ACP agent engine */
+export function isAcpEngineType(engineType: string): boolean {
+  return engineType.startsWith(ACP_ENGINE_PREFIX)
+}
+
+/** Extract ACP agent ID from a virtual engine type (e.g. "acp:codex" → "codex") */
+export function parseAcpEngineType(engineType: string): AcpAgentId | null {
+  if (!isAcpEngineType(engineType)) return null
+  return engineType.slice(ACP_ENGINE_PREFIX.length) as AcpAgentId
+}
+
+/**
+ * Expand a single "acp" engine + models into per-agent virtual engines.
+ *
+ * Input:  engines=[{engineType:'acp', ...}], models={acp: [{id:'acp:gemini:...'}, ...]}
+ * Output: engines=[{engineType:'acp:gemini',...}, {engineType:'acp:codex',...}],
+ *         models={'acp:gemini': [...], 'acp:codex': [...]}
+ */
+function expandAcpEngines(discovery: EngineDiscovery): EngineDiscovery {
+  const acpEntry = discovery.engines.find(e => e.engineType === 'acp')
+  const acpModels = discovery.models.acp
+
+  if (!acpEntry || !acpModels || acpModels.length === 0) {
+    // No ACP or no models — remove ACP entirely, nothing to split
+    return {
+      engines: discovery.engines.filter(e => e.engineType !== 'acp'),
+      models: Object.fromEntries(
+        Object.entries(discovery.models).filter(([k]) => k !== 'acp'),
+      ),
+    }
+  }
+
+  const agents = getAcpAgents()
+  const agentMap = new Map(agents.map(a => [a.id, a]))
+
+  // Group models by agent prefix
+  const modelsByAgent = new Map<string, EngineModel[]>()
+  for (const model of acpModels) {
+    const match = model.id.match(/^acp:([\w-]+):/)
+    const agentId = match?.[1] ?? 'gemini'
+    const arr = modelsByAgent.get(agentId)
+    if (arr) arr.push(model)
+    else modelsByAgent.set(agentId, [model])
+  }
+
+  // Build per-agent engine entries
+  const expandedEngines: EngineAvailability[] = []
+  const expandedModels: Record<string, EngineModel[]> = {}
+
+  for (const [agentId, models] of modelsByAgent) {
+    const agent = agentMap.get(agentId as AcpAgentId)
+    const virtualType = toAcpEngineType(agentId as AcpAgentId)
+    expandedEngines.push({
+      ...acpEntry,
+      engineType: virtualType as EngineAvailability['engineType'],
+      version: agent?.label,
+    })
+    expandedModels[virtualType] = models
+  }
+
+  return {
+    engines: [
+      ...discovery.engines.filter(e => e.engineType !== 'acp'),
+      ...expandedEngines,
+    ],
+    models: {
+      ...Object.fromEntries(
+        Object.entries(discovery.models).filter(([k]) => k !== 'acp'),
+      ),
+      ...expandedModels,
+    },
+  }
+}
+
 // In-flight probe dedup: prevents concurrent live probes from spawning duplicate processes
 let probeInFlight: Promise<EngineDiscovery> | null = null
 
@@ -216,7 +302,7 @@ let probeInFlight: Promise<EngineDiscovery> | null = null
 export async function getEngineDiscovery(): Promise<EngineDiscovery> {
   // 1. Memory cache
   const cached = await readFromCache()
-  if (cached) return cached
+  if (cached) return expandAcpEngines(cached)
 
   // 2. DB
   const dbData = await getProbeResults()
@@ -229,7 +315,7 @@ export async function getEngineDiscovery(): Promise<EngineDiscovery> {
       'probe_loaded_from_db',
     )
     await writeToCache(dbData.engines, dbData.models)
-    return dbData
+    return expandAcpEngines(dbData)
   }
 
   // 3. Live probe (deduped: concurrent callers share the same in-flight probe)
@@ -254,7 +340,7 @@ export async function getEngineDiscovery(): Promise<EngineDiscovery> {
       'probe_completed',
     )
 
-    return discovery
+    return expandAcpEngines(discovery)
   })().finally(() => {
     probeInFlight = null
   })
@@ -283,7 +369,8 @@ export async function forceProbeEngines(): Promise<ProbeResult> {
     'force_probe_completed',
   )
 
-  return { engines, models, duration }
+  const expanded = expandAcpEngines({ engines, models })
+  return { engines: expanded.engines, models: expanded.models, duration }
 }
 
 /**

--- a/apps/api/src/engines/startup-probe.ts
+++ b/apps/api/src/engines/startup-probe.ts
@@ -225,14 +225,9 @@ export function toAcpEngineType(agentId: AcpAgentId): string {
   return `${ACP_ENGINE_PREFIX}${agentId}`
 }
 
-/** Check if an engine type is a virtual ACP agent engine */
-export function isAcpEngineType(engineType: string): boolean {
-  return engineType.startsWith(ACP_ENGINE_PREFIX)
-}
-
-/** Extract ACP agent ID from a virtual engine type (e.g. "acp:codex" → "codex") */
+/** Extract ACP agent ID from a validated virtual engine type (e.g. "acp:codex" → "codex") */
 export function parseAcpEngineType(engineType: string): AcpAgentId | null {
-  if (!isAcpEngineType(engineType)) return null
+  if (!isValidAcpEngineType(engineType)) return null
   return engineType.slice(ACP_ENGINE_PREFIX.length) as AcpAgentId
 }
 
@@ -264,6 +259,9 @@ function expandAcpEngines(discovery: EngineDiscovery): EngineDiscovery {
   const modelsByAgent = new Map<string, EngineModel[]>()
   for (const model of acpModels) {
     const match = model.id.match(/^acp:([\w-]+):/)
+    if (!match) {
+      logger.warn({ modelId: model.id }, 'acp_model_missing_agent_prefix_defaulting_to_gemini')
+    }
     const agentId = match?.[1] ?? 'gemini'
     const arr = modelsByAgent.get(agentId)
     if (arr) arr.push(model)

--- a/apps/api/src/engines/startup-probe.ts
+++ b/apps/api/src/engines/startup-probe.ts
@@ -210,6 +210,16 @@ async function discoverSlashCommands(installed: EngineAvailability[]): Promise<v
 /** ACP agent prefix for virtual engine types (e.g. "acp:gemini") */
 export const ACP_ENGINE_PREFIX = 'acp:'
 
+/** Known ACP agent IDs — used for input validation */
+export const KNOWN_ACP_AGENT_IDS: readonly string[] = ['gemini', 'codex', 'claude']
+
+/** Check if a string is a valid ACP virtual engine type with a known agent ID */
+export function isValidAcpEngineType(engineType: string): boolean {
+  if (!engineType.startsWith(ACP_ENGINE_PREFIX)) return false
+  const agentId = engineType.slice(ACP_ENGINE_PREFIX.length)
+  return KNOWN_ACP_AGENT_IDS.includes(agentId)
+}
+
 /** Build a virtual engine type key for an ACP agent */
 export function toAcpEngineType(agentId: AcpAgentId): string {
   return `${ACP_ENGINE_PREFIX}${agentId}`

--- a/apps/api/src/engines/startup-probe.ts
+++ b/apps/api/src/engines/startup-probe.ts
@@ -242,22 +242,19 @@ function expandAcpEngines(discovery: EngineDiscovery): EngineDiscovery {
   const acpEntry = discovery.engines.find(e => e.engineType === 'acp')
   const acpModels = discovery.models.acp
 
-  if (!acpEntry || !acpModels || acpModels.length === 0) {
-    // No ACP or no models — remove ACP entirely, nothing to split
-    return {
-      engines: discovery.engines.filter(e => e.engineType !== 'acp'),
-      models: Object.fromEntries(
-        Object.entries(discovery.models).filter(([k]) => k !== 'acp'),
-      ),
-    }
+  if (!acpEntry) {
+    // No ACP executor at all — nothing to expand
+    return discovery
   }
 
-  const agents = getAcpAgents()
-  const agentMap = new Map(agents.map(a => [a.id, a]))
+  // Even if no models were discovered, still show per-agent engine entries
+  // so users can see which ACP agents are available.
 
-  // Group models by agent prefix
+  const agents = getAcpAgents()
+
+  // Group models by agent prefix (if any models exist)
   const modelsByAgent = new Map<string, EngineModel[]>()
-  for (const model of acpModels) {
+  for (const model of (acpModels ?? [])) {
     const match = model.id.match(/^acp:([\w-]+):/)
     if (!match) {
       logger.warn({ modelId: model.id }, 'acp_model_missing_agent_prefix_defaulting_to_gemini')
@@ -268,19 +265,18 @@ function expandAcpEngines(discovery: EngineDiscovery): EngineDiscovery {
     else modelsByAgent.set(agentId, [model])
   }
 
-  // Build per-agent engine entries
+  // Build per-agent engine entries — always create entries for all known agents
   const expandedEngines: EngineAvailability[] = []
   const expandedModels: Record<string, EngineModel[]> = {}
 
-  for (const [agentId, models] of modelsByAgent) {
-    const agent = agentMap.get(agentId as AcpAgentId)
-    const virtualType = toAcpEngineType(agentId as AcpAgentId)
+  for (const agent of agents) {
+    const virtualType = toAcpEngineType(agent.id)
     expandedEngines.push({
       ...acpEntry,
       engineType: virtualType as EngineAvailability['engineType'],
-      version: agent?.label,
+      version: agent.label,
     })
-    expandedModels[virtualType] = models
+    expandedModels[virtualType] = modelsByAgent.get(agent.id) ?? []
   }
 
   return {

--- a/apps/api/src/engines/types.ts
+++ b/apps/api/src/engines/types.ts
@@ -3,7 +3,7 @@ import type { Subprocess } from '@/engines/spawn'
 // ---------- Enums / Literal Unions ----------
 
 // Supported AI engine types
-export type EngineType = 'claude-code' | 'codex' | 'acp' | 'echo'
+export type EngineType = 'claude-code' | 'codex' | 'acp' | `acp:${string}`
 
 // Communication protocols
 export type EngineProtocol = 'stream-json' | 'json-rpc' | 'acp'
@@ -215,7 +215,7 @@ export interface EngineRegistry {
 // ---------- Constants ----------
 
 // Default built-in engine profiles
-export const BUILT_IN_PROFILES: Record<EngineType, EngineProfile> = {
+export const BUILT_IN_PROFILES: Partial<Record<EngineType, EngineProfile>> & Record<'claude-code' | 'codex' | 'acp', EngineProfile> = {
   'claude-code': {
     engineType: 'claude-code',
     name: 'Claude Code',
@@ -237,14 +237,6 @@ export const BUILT_IN_PROFILES: Record<EngineType, EngineProfile> = {
     name: 'ACP Agents',
     baseCommand: 'dynamic (selected by model prefix)',
     protocol: 'acp',
-    capabilities: ['session-fork'],
-    permissionPolicy: 'auto',
-  },
-  'echo': {
-    engineType: 'echo',
-    name: 'Echo (Mock)',
-    baseCommand: 'echo',
-    protocol: 'stream-json',
     capabilities: ['session-fork'],
     permissionPolicy: 'auto',
   },

--- a/apps/api/src/routes/engines.ts
+++ b/apps/api/src/routes/engines.ts
@@ -11,15 +11,15 @@ import {
 } from '@/db/helpers'
 import { engineRegistry } from '@/engines/executors'
 import { getAcpAgents } from '@/engines/executors/acp/agents'
-import { forceProbeEngines, getEngineDiscovery, getEngineModels, toAcpEngineType } from '@/engines/startup-probe'
+import { forceProbeEngines, getEngineDiscovery, getEngineModels, isValidAcpEngineType, toAcpEngineType } from '@/engines/startup-probe'
 import type { EngineProfile } from '@/engines/types'
 import { BUILT_IN_PROFILES } from '@/engines/types'
 
 const ENGINE_TYPES = ['claude-code', 'codex', 'acp'] as const
 
-/** Accept both base engine types and virtual ACP types (e.g. "acp:codex") */
+/** Accept both base engine types and known virtual ACP types (e.g. "acp:codex") */
 const engineTypeOrAcpEnum = z.string().refine(
-  val => ENGINE_TYPES.includes(val as typeof ENGINE_TYPES[number]) || val.startsWith('acp:'),
+  val => ENGINE_TYPES.includes(val as typeof ENGINE_TYPES[number]) || isValidAcpEngineType(val),
   { message: 'Invalid engine type' },
 )
 

--- a/apps/api/src/routes/engines.ts
+++ b/apps/api/src/routes/engines.ts
@@ -118,7 +118,7 @@ engines.patch(
 // PATCH /api/engines/:engineType/hidden-models — Update hidden models for an engine type
 engines.patch(
   '/:engineType/hidden-models',
-  zValidator('json', z.object({ hiddenModels: z.array(z.string().regex(/^[\w./:-]{1,160}$/)).max(500) }), (result, c) => {
+  zValidator('json', z.object({ hiddenModels: z.array(z.string().regex(/^[\w./:\-[\]]{1,160}$/)).max(500) }), (result, c) => {
     if (!result.success) {
       return c.json(
         {

--- a/apps/api/src/routes/engines.ts
+++ b/apps/api/src/routes/engines.ts
@@ -118,7 +118,7 @@ engines.patch(
 // PATCH /api/engines/:engineType/hidden-models — Update hidden models for an engine type
 engines.patch(
   '/:engineType/hidden-models',
-  zValidator('json', z.object({ hiddenModels: z.array(z.string()) }), (result, c) => {
+  zValidator('json', z.object({ hiddenModels: z.array(z.string().regex(/^[\w./:-]{1,160}$/)).max(500) }), (result, c) => {
     if (!result.success) {
       return c.json(
         {

--- a/apps/api/src/routes/engines.ts
+++ b/apps/api/src/routes/engines.ts
@@ -3,16 +3,25 @@ import { Hono } from 'hono'
 import * as z from 'zod'
 import {
   getAllEngineDefaultModels,
+  getAllEngineHiddenModels,
   getDefaultEngine,
   setDefaultEngine,
   setEngineDefaultModel,
+  setEngineHiddenModels,
 } from '@/db/helpers'
 import { engineRegistry } from '@/engines/executors'
-import { forceProbeEngines, getEngineDiscovery, getEngineModels } from '@/engines/startup-probe'
+import { getAcpAgents } from '@/engines/executors/acp/agents'
+import { forceProbeEngines, getEngineDiscovery, getEngineModels, toAcpEngineType } from '@/engines/startup-probe'
+import type { EngineProfile } from '@/engines/types'
 import { BUILT_IN_PROFILES } from '@/engines/types'
 
-const ENGINE_TYPES = ['claude-code', 'codex', 'acp', 'echo'] as const
-const engineTypeEnum = z.enum(ENGINE_TYPES)
+const ENGINE_TYPES = ['claude-code', 'codex', 'acp'] as const
+
+/** Accept both base engine types and virtual ACP types (e.g. "acp:codex") */
+const engineTypeOrAcpEnum = z.string().refine(
+  val => ENGINE_TYPES.includes(val as typeof ENGINE_TYPES[number]) || val.startsWith('acp:'),
+  { message: 'Invalid engine type' },
+)
 
 const engines = new Hono()
 
@@ -22,21 +31,38 @@ engines.get('/available', async (c) => {
   return c.json({ success: true, data: { engines, models } })
 })
 
-// GET /api/engines/profiles — List engine profiles
+// GET /api/engines/profiles — List engine profiles (ACP expanded into per-agent profiles)
 engines.get('/profiles', (c) => {
-  const profiles = Object.values(BUILT_IN_PROFILES)
+  const baseProfiles = Object.values(BUILT_IN_PROFILES)
+  const acpProfile = BUILT_IN_PROFILES.acp
+  const agents = getAcpAgents()
+
+  // Replace the single ACP profile with per-agent profiles
+  const profiles: EngineProfile[] = [
+    ...baseProfiles.filter(p => p.engineType !== 'acp'),
+    ...agents.map(agent => ({
+      ...acpProfile,
+      engineType: toAcpEngineType(agent.id) as EngineProfile['engineType'],
+      name: `ACP: ${agent.label}`,
+    })),
+  ]
+
   return c.json({ success: true, data: profiles })
 })
 
-// GET /api/engines/settings — Get all engine settings (default engine + per-engine default models)
+// GET /api/engines/settings — Get all engine settings (default engine + per-engine models + hidden)
 engines.get('/settings', async (c) => {
-  const [defaults, defaultEngine] = await Promise.all([
+  const [defaults, hiddenModels, defaultEngine] = await Promise.all([
     getAllEngineDefaultModels(),
+    getAllEngineHiddenModels(),
     getDefaultEngine(),
   ])
-  const engines: Record<string, { defaultModel: string }> = {}
+  const engines: Record<string, { defaultModel?: string, hiddenModels?: string[] }> = {}
   for (const [engineType, model] of Object.entries(defaults)) {
-    engines[engineType] = { defaultModel: model }
+    engines[engineType] = { ...engines[engineType], defaultModel: model }
+  }
+  for (const [engineType, hidden] of Object.entries(hiddenModels)) {
+    engines[engineType] = { ...engines[engineType], hiddenModels: hidden }
   }
   return c.json({ success: true, data: { defaultEngine, engines } })
 })
@@ -44,7 +70,7 @@ engines.get('/settings', async (c) => {
 // PATCH /api/engines/default-engine — Update global default engine
 engines.patch(
   '/default-engine',
-  zValidator('json', z.object({ defaultEngine: engineTypeEnum }), (result, c) => {
+  zValidator('json', z.object({ defaultEngine: engineTypeOrAcpEnum }), (result, c) => {
     if (!result.success) {
       return c.json(
         {
@@ -78,7 +104,7 @@ engines.patch(
   }),
   async (c) => {
     const rawType = c.req.param('engineType')
-    const parsed = engineTypeEnum.safeParse(rawType)
+    const parsed = engineTypeOrAcpEnum.safeParse(rawType)
     if (!parsed.success) {
       return c.json({ success: false, error: `Unknown engine type: ${rawType}` }, 400)
     }
@@ -89,20 +115,53 @@ engines.patch(
   },
 )
 
+// PATCH /api/engines/:engineType/hidden-models — Update hidden models for an engine type
+engines.patch(
+  '/:engineType/hidden-models',
+  zValidator('json', z.object({ hiddenModels: z.array(z.string()) }), (result, c) => {
+    if (!result.success) {
+      return c.json(
+        {
+          success: false,
+          error: result.error.issues.map(i => i.message).join(', '),
+        },
+        400,
+      )
+    }
+  }),
+  async (c) => {
+    const rawType = c.req.param('engineType')
+    const parsed = engineTypeOrAcpEnum.safeParse(rawType)
+    if (!parsed.success) {
+      return c.json({ success: false, error: `Unknown engine type: ${rawType}` }, 400)
+    }
+    const engineType = parsed.data
+    const { hiddenModels } = c.req.valid('json')
+    await setEngineHiddenModels(engineType, hiddenModels)
+    return c.json({ success: true, data: { engineType, hiddenModels } })
+  },
+)
+
 // GET /api/engines/:engineType/models — List available models for an engine
 engines.get('/:engineType/models', async (c) => {
   const rawType = c.req.param('engineType')
-  const parsed = engineTypeEnum.safeParse(rawType)
+  const parsed = engineTypeOrAcpEnum.safeParse(rawType)
   if (!parsed.success) {
     return c.json({ success: false, error: `Unknown engine type: ${rawType}` }, 400)
   }
   const engineType = parsed.data
-  const executor = engineRegistry.get(engineType)
+  // For virtual ACP types, resolve to base 'acp' executor
+  const lookupType = engineType.startsWith('acp:') ? 'acp' : engineType
+  const executor = engineRegistry.get(lookupType as typeof ENGINE_TYPES[number])
   if (!executor) {
     return c.json({ success: false, error: `Unknown engine type: ${engineType}` }, 404)
   }
 
-  const models = await getEngineModels(engineType)
+  const allModels = await getEngineModels(lookupType as typeof ENGINE_TYPES[number])
+  // For virtual ACP types, filter to only models matching the agent prefix
+  const models = engineType.startsWith('acp:')
+    ? allModels.filter(m => m.id.startsWith(`${engineType}:`))
+    : allModels
   const defaultModel = models.find(m => m.isDefault)?.id
 
   return c.json({

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -25,7 +25,10 @@ export const createIssueSchema = z.object({
   statusId: z.enum(STATUS_IDS),
   parentIssueId: z.string().optional(),
   useWorktree: z.boolean().optional(),
-  engineType: z.enum(['claude-code', 'codex', 'acp', 'echo']).optional(),
+  engineType: z.string().refine(
+    val => ['claude-code', 'codex', 'acp'].includes(val) || val.startsWith('acp:'),
+    { message: 'Invalid engine type' },
+  ).optional(),
   model: z
     .string()
     .regex(/^[\w./:-]{1,160}$/)
@@ -54,7 +57,10 @@ export const updateIssueSchema = z.object({
 })
 
 export const executeIssueSchema = z.object({
-  engineType: z.enum(['claude-code', 'codex', 'acp', 'echo']),
+  engineType: z.string().refine(
+    val => ['claude-code', 'codex', 'acp'].includes(val) || val.startsWith('acp:'),
+    { message: 'Invalid engine type' },
+  ),
   prompt: z.string().min(1).max(32768),
   model: z
     .string()
@@ -285,7 +291,7 @@ export function triggerIssueExecution(
         basePrompt
 
       await issueEngine.executeIssue(issueId, {
-        engineType: (issue.engineType ?? 'echo') as EngineType,
+        engineType: (issue.engineType ?? 'claude-code') as EngineType,
         prompt: effectivePrompt,
         workingDir: effectiveWorkingDir,
         model: issue.model ?? undefined,

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -12,6 +12,7 @@ import {
 } from '@/db/pending-messages'
 import { issues as issuesTable } from '@/db/schema'
 import { issueEngine } from '@/engines/issue'
+import { isValidAcpEngineType } from '@/engines/startup-probe'
 import type { EngineType } from '@/engines/types'
 import { emitIssueLogRemoved, emitIssueUpdated } from '@/events/issue-events'
 import { logger } from '@/logger'
@@ -26,7 +27,7 @@ export const createIssueSchema = z.object({
   parentIssueId: z.string().optional(),
   useWorktree: z.boolean().optional(),
   engineType: z.string().refine(
-    val => ['claude-code', 'codex', 'acp'].includes(val) || val.startsWith('acp:'),
+    val => ['claude-code', 'codex', 'acp'].includes(val) || isValidAcpEngineType(val),
     { message: 'Invalid engine type' },
   ).optional(),
   model: z
@@ -58,7 +59,7 @@ export const updateIssueSchema = z.object({
 
 export const executeIssueSchema = z.object({
   engineType: z.string().refine(
-    val => ['claude-code', 'codex', 'acp'].includes(val) || val.startsWith('acp:'),
+    val => ['claude-code', 'codex', 'acp'].includes(val) || isValidAcpEngineType(val),
     { message: 'Invalid engine type' },
   ),
   prompt: z.string().min(1).max(32768),

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -32,7 +32,7 @@ export const createIssueSchema = z.object({
   ).optional(),
   model: z
     .string()
-    .regex(/^[\w./:-]{1,160}$/)
+    .regex(/^[\w./:\-[\]]{1,160}$/)
     .optional(),
   permissionMode: z.enum(['auto', 'supervised', 'plan']).optional(),
 })
@@ -65,7 +65,7 @@ export const executeIssueSchema = z.object({
   prompt: z.string().min(1).max(32768),
   model: z
     .string()
-    .regex(/^[\w./:-]{1,160}$/)
+    .regex(/^[\w./:\-[\]]{1,160}$/)
     .optional(),
   permissionMode: z.enum(['auto', 'supervised', 'plan']).optional(),
 })

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -27,7 +27,7 @@ export const createIssueSchema = z.object({
   parentIssueId: z.string().optional(),
   useWorktree: z.boolean().optional(),
   engineType: z.string().refine(
-    val => ['claude-code', 'codex', 'acp'].includes(val) || isValidAcpEngineType(val),
+    val => ['claude-code', 'codex', 'acp', 'echo'].includes(val) || isValidAcpEngineType(val),
     { message: 'Invalid engine type' },
   ).optional(),
   model: z
@@ -59,7 +59,7 @@ export const updateIssueSchema = z.object({
 
 export const executeIssueSchema = z.object({
   engineType: z.string().refine(
-    val => ['claude-code', 'codex', 'acp'].includes(val) || isValidAcpEngineType(val),
+    val => ['claude-code', 'codex', 'acp', 'echo'].includes(val) || isValidAcpEngineType(val),
     { message: 'Invalid engine type' },
   ),
   prompt: z.string().min(1).max(32768),

--- a/apps/api/src/routes/issues/create.ts
+++ b/apps/api/src/routes/issues/create.ts
@@ -43,12 +43,13 @@ create.post(
     const body = c.req.valid('json')
 
     // Resolve engine/model defaults when not explicitly provided
-    // Falls back to 'echo' / 'auto' when no settings exist
     let resolvedEngine = body.engineType ?? null
     let resolvedModel = body.model ?? null
 
     if (!resolvedEngine) {
-      resolvedEngine = ((await getDefaultEngine()) || 'claude-code') as EngineType
+      const defaultEng = (await getDefaultEngine()) || 'claude-code'
+      // Legacy bare 'acp' maps to 'acp:gemini' (the default ACP agent)
+      resolvedEngine = (defaultEng === 'acp' ? 'acp:gemini' : defaultEng) as EngineType
     }
     if (!resolvedModel) {
       // Leave model unset — let the engine CLI use its own default.

--- a/apps/api/src/routes/issues/create.ts
+++ b/apps/api/src/routes/issues/create.ts
@@ -49,14 +49,18 @@ create.post(
     let resolvedModel = body.model ?? null
 
     if (!resolvedEngine) {
-      resolvedEngine = ((await getDefaultEngine()) || 'echo') as EngineType
+      resolvedEngine = ((await getDefaultEngine()) || 'claude-code') as EngineType
     }
     if (!resolvedModel) {
       const savedModel = await getEngineDefaultModel(resolvedEngine!)
       if (savedModel) {
         resolvedModel = savedModel
       } else {
-        const models = await engineRegistry.getModels(resolvedEngine as EngineType)
+        const allModels = await engineRegistry.getModels(resolvedEngine as EngineType)
+        // For virtual ACP types (e.g. "acp:claude"), filter to only models scoped to that agent
+        const models = resolvedEngine!.startsWith('acp:')
+          ? allModels.filter(m => m.id.startsWith(`${resolvedEngine}:`))
+          : allModels
         resolvedModel = models.find(m => m.isDefault)?.id ?? models[0]?.id ?? 'auto'
       }
     }

--- a/apps/api/src/routes/issues/create.ts
+++ b/apps/api/src/routes/issues/create.ts
@@ -6,7 +6,6 @@ import { cacheDel, cacheDelByPrefix } from '@/cache'
 import { db } from '@/db'
 import { findProject, getDefaultEngine, getEngineDefaultModel, getServerUrl } from '@/db/helpers'
 import { issues as issuesTable } from '@/db/schema'
-import { engineRegistry } from '@/engines/executors'
 import type { EngineType } from '@/engines/types'
 import { logger } from '@/logger'
 import { buildIssueUrl, dispatch as webhookDispatch } from '@/webhooks/dispatcher'
@@ -52,16 +51,11 @@ create.post(
       resolvedEngine = ((await getDefaultEngine()) || 'claude-code') as EngineType
     }
     if (!resolvedModel) {
+      // Leave model unset — let the engine CLI use its own default.
+      // Only fill from saved settings if the user explicitly configured one.
       const savedModel = await getEngineDefaultModel(resolvedEngine!)
-      if (savedModel) {
+      if (savedModel && savedModel !== 'auto') {
         resolvedModel = savedModel
-      } else {
-        const allModels = await engineRegistry.getModels(resolvedEngine as EngineType)
-        // For virtual ACP types (e.g. "acp:claude"), filter to only models scoped to that agent
-        const models = resolvedEngine!.startsWith('acp:')
-          ? allModels.filter(m => m.id.startsWith(`${resolvedEngine}:`))
-          : allModels
-        resolvedModel = models.find(m => m.isDefault)?.id ?? models[0]?.id ?? 'auto'
       }
     }
 

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -160,15 +160,6 @@ async function upsertAndNotify(
 
 const message = new Hono()
 
-function isFollowUpModelChangeBlocked(
-  issue: { externalSessionId: string | null, model: string | null },
-  requestedModel?: string,
-): boolean {
-  if (!issue.externalSessionId) return false
-  if (!requestedModel) return false
-  return requestedModel !== (issue.model ?? '')
-}
-
 // POST /api/projects/:projectId/issues/:id/follow-up — Follow-up
 message.post('/:id/follow-up', async (c) => {
   const projectId = c.req.param('projectId')!
@@ -200,16 +191,6 @@ message.post('/:id/follow-up', async (c) => {
   const issue = await getProjectOwnedIssue(project.id, issueId)
   if (!issue) {
     return c.json({ success: false, error: 'Issue not found' }, 404)
-  }
-
-  if (isFollowUpModelChangeBlocked(issue, parsed.model)) {
-    return c.json(
-      {
-        success: false,
-        error: 'Model changes are not allowed during an existing session. Restart to use a different model.',
-      },
-      409,
-    )
   }
 
   const pendingBefore = await getPendingMessages(issueId)

--- a/apps/api/src/routes/issues/message.ts
+++ b/apps/api/src/routes/issues/message.ts
@@ -193,6 +193,15 @@ message.post('/:id/follow-up', async (c) => {
     return c.json({ success: false, error: 'Issue not found' }, 404)
   }
 
+  // Reject model changes while the session is actively running
+  const isActive = issue.sessionStatus === 'running' || issue.sessionStatus === 'pending'
+  if (isActive && parsed.model && parsed.model !== (issue.model ?? '')) {
+    return c.json(
+      { success: false, error: 'Cannot change model while session is running. Wait for completion or cancel first.' },
+      409,
+    )
+  }
+
   const pendingBefore = await getPendingMessages(issueId)
 
   // Save uploaded files and insert attachment records

--- a/apps/api/src/routes/settings/general.ts
+++ b/apps/api/src/routes/settings/general.ts
@@ -315,9 +315,9 @@ general.patch(
 
 // GET /api/settings/slash-commands?engine=claude-code
 general.get('/slash-commands', async (c) => {
-  const validEngines = ['claude-code', 'codex', 'acp', 'echo']
+  const validEngines = ['claude-code', 'codex', 'acp']
   const rawEngine = c.req.query('engine')
-  if (rawEngine && !validEngines.includes(rawEngine)) {
+  if (rawEngine && !validEngines.includes(rawEngine) && !rawEngine.startsWith('acp:')) {
     return c.json({ success: false, error: `Invalid engine type: ${rawEngine}` }, 400)
   }
   const engine = rawEngine as import('@/engines/types').EngineType | undefined

--- a/apps/api/test/api-engines.test.ts
+++ b/apps/api/test/api-engines.test.ts
@@ -50,11 +50,11 @@ describe('GET /api/engines/settings', () => {
 describe('PATCH /api/engines/default-engine', () => {
   test('sets a valid default engine', async () => {
     const result = await patch<{ defaultEngine: string }>('/api/engines/default-engine', {
-      defaultEngine: 'echo',
+      defaultEngine: 'claude-code',
     })
     expect(result.status).toBe(200)
     const data = expectSuccess(result)
-    expect(data.defaultEngine).toBe('echo')
+    expect(data.defaultEngine).toBe('claude-code')
   })
 
   test('rejects invalid engine type', async () => {
@@ -76,10 +76,10 @@ describe('GET /api/engines/:engineType/models', () => {
       engineType: string
       defaultModel: string | undefined
       models: unknown[]
-    }>('/api/engines/echo/models')
+    }>('/api/engines/claude-code/models')
     expect(result.status).toBe(200)
     const data = expectSuccess(result)
-    expect(data.engineType).toBe('echo')
+    expect(data.engineType).toBe('claude-code')
     expect(Array.isArray(data.models)).toBe(true)
   })
 

--- a/apps/api/test/api-execution.test.ts
+++ b/apps/api/test/api-execution.test.ts
@@ -185,10 +185,10 @@ describe('POST /api/projects/:projectId/issues/:id/follow-up', () => {
     expectSuccess(result)
   })
 
-  test('rejects follow-up model change once a session exists', async () => {
+  test('allows follow-up model change during an existing session', async () => {
     const issue = expectSuccess(
       await createTestIssue(projectId, {
-        title: 'Locked Model Follow Up',
+        title: 'Model Switch Follow Up',
         statusId: 'working',
         engineType: 'echo',
       }),
@@ -203,11 +203,7 @@ describe('POST /api/projects/:projectId/issues/:id/follow-up', () => {
       prompt: 'Switch model',
       model: 'different-model',
     })
-    expect(result.status).toBe(409)
-    expect(result.json.success).toBe(false)
-    if (!result.json.success) {
-      expect(result.json.error).toContain('Restart')
-    }
+    expectSuccess(result)
   })
 
   test('rejects follow-up with empty prompt', async () => {

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -87,7 +87,7 @@ export async function createTestIssue(
   const result = await post<Record<string, unknown>>(`/api/projects/${projectId}/issues`, {
     title: opts.title ?? 'Test Issue',
     statusId: opts.statusId ?? 'todo',
-    engineType: opts.engineType ?? 'echo',
+    engineType: opts.engineType ?? 'claude-code',
     model: opts.model ?? 'auto',
     description: opts.description,
   })

--- a/apps/api/test/preload.ts
+++ b/apps/api/test/preload.ts
@@ -25,6 +25,8 @@ if (!existsSync(testDir)) {
 ;(globalThis as any).__TEST_DB_PATH = testDbPath
 
 // Register echo executor for tests (removed from production registry)
+// eslint-disable-next-line antfu/no-top-level-await
 const { engineRegistry } = await import('@/engines/executors')
+// eslint-disable-next-line antfu/no-top-level-await
 const { EchoExecutor } = await import('@/engines/executors/echo/executor')
 ;(engineRegistry as any).register(new EchoExecutor())

--- a/apps/api/test/preload.ts
+++ b/apps/api/test/preload.ts
@@ -23,3 +23,8 @@ if (!existsSync(testDir)) {
 }
 // Store path for cleanup
 ;(globalThis as any).__TEST_DB_PATH = testDbPath
+
+// Register echo executor for tests (removed from production registry)
+const { engineRegistry } = await import('@/engines/executors')
+const { EchoExecutor } = await import('@/engines/executors/echo/executor')
+;(engineRegistry as any).register(new EchoExecutor())

--- a/apps/frontend/src/__tests__/lib/format.test.ts
+++ b/apps/frontend/src/__tests__/lib/format.test.ts
@@ -48,12 +48,16 @@ describe('formatModelName', () => {
     expect(formatModelName('claude-opus-4-5[thinking]')).toBe('Claude Opus 4.5[thinking]')
   })
 
-  it('formats scoped acp gemini model ids', () => {
-    expect(formatModelName('acp:gemini:gemini-2.5-pro')).toBe('Gemini / gemini-2.5-pro')
+  it('strips acp agent prefix for display', () => {
+    expect(formatModelName('acp:gemini:gemini-2.5-pro')).toBe('gemini-2.5-pro')
   })
 
-  it('formats scoped acp codex model ids', () => {
-    expect(formatModelName('acp:codex:gpt-5.4')).toBe('Codex / gpt-5.4')
+  it('strips acp codex prefix for display', () => {
+    expect(formatModelName('acp:codex:gpt-5.4')).toBe('gpt-5.4')
+  })
+
+  it('formats acp claude model with claude pattern', () => {
+    expect(formatModelName('acp:claude:claude-sonnet-4-5')).toBe('Claude Sonnet 4.5')
   })
 })
 

--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -63,6 +63,7 @@ import {
   useSystemInfo,
   useSystemLogs,
   useUpdateDefaultEngine,
+  useUpdateEngineHiddenModels,
   useUpdateEngineModelSetting,
   useUpdateServerInfo,
   useUpdateWorkspacePath,
@@ -823,6 +824,7 @@ function ModelsSection({ open }: { open: boolean }) {
   const { data: profiles } = useEngineProfiles(open)
   const { data: engineSettings } = useEngineSettings(open)
   const updateModelSetting = useUpdateEngineModelSetting()
+  const updateHiddenModels = useUpdateEngineHiddenModels()
   const updateDefaultEngine = useUpdateDefaultEngine()
   const probe = useProbeEngines()
   const showNoAvailableEngines = !enginesLoading && availableEngines.length === 0
@@ -889,18 +891,24 @@ function ModelsSection({ open }: { open: boolean }) {
                 availableEngines.map((engine) => {
                   const profile = profiles?.find(p => p.engineType === engine.engineType)
                   const engineModels = models?.[engine.engineType] ?? []
-                  const savedDefault = engineSettings?.engines[engine.engineType]?.defaultModel
+                  const engineSetting = engineSettings?.engines[engine.engineType]
                   return (
                     <EngineCard
                       key={engine.engineType}
                       engine={engine}
                       profile={profile}
                       models={engineModels}
-                      savedDefault={savedDefault}
+                      savedDefault={engineSetting?.defaultModel}
+                      hiddenModels={engineSetting?.hiddenModels ?? []}
                       onChangeDefault={modelId =>
                         updateModelSetting.mutate({
                           engineType: engine.engineType,
                           defaultModel: modelId,
+                        })}
+                      onChangeHiddenModels={hiddenModels =>
+                        updateHiddenModels.mutate({
+                          engineType: engine.engineType,
+                          hiddenModels,
                         })}
                     />
                   )
@@ -1289,13 +1297,17 @@ function EngineCard({
   profile,
   models,
   savedDefault,
+  hiddenModels,
   onChangeDefault,
+  onChangeHiddenModels,
 }: {
   engine: EngineAvailability
   profile?: EngineProfile
   models: EngineModel[]
   savedDefault?: string
+  hiddenModels: string[]
   onChangeDefault: (modelId: string) => void
+  onChangeHiddenModels: (hiddenModels: string[]) => void
 }) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
@@ -1303,6 +1315,12 @@ function EngineCard({
   const builtInDefault = models.find(m => m.isDefault)
   const selectedModel = savedDefault ?? builtInDefault?.id ?? ''
   const selectedModelName = models.find(m => m.id === selectedModel)?.name
+  const hiddenSet = useMemo(() => new Set(hiddenModels), [hiddenModels])
+  const visibleModels = useMemo(
+    () => models.filter(m => !hiddenSet.has(m.id)),
+    [models, hiddenSet],
+  )
+  const visibleCount = visibleModels.length
 
   return (
     <div className="rounded-lg border overflow-hidden">
@@ -1348,7 +1366,11 @@ function EngineCard({
               null}
             {hasModels ?
                 (
-                  <span className="shrink-0">{t('settings.models', { count: models.length })}</span>
+                  <span className="shrink-0">
+                    {visibleCount < models.length
+                      ? `${visibleCount}/${models.length}`
+                      : t('settings.models', { count: models.length })}
+                  </span>
                 ) :
               null}
           </div>
@@ -1390,42 +1412,66 @@ function EngineCard({
         </div>
       </button>
 
-      {expanded && hasModels ?
-          (
-            <div className="border-t px-3 py-2 flex flex-col gap-1">
-              <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-0.5">
-                {t('settings.defaultModel')}
-              </span>
+      {expanded && hasModels
+        ? (
+            <div className="border-t px-3 py-2 flex flex-col gap-0.5">
               {models.map((m) => {
-                const isSelected = m.id === selectedModel
+                const isHidden = hiddenSet.has(m.id)
+                const isDefault = m.id === selectedModel
                 return (
-                  <button
+                  <div
                     key={m.id}
-                    type="button"
-                    onClick={() => !isSelected && onChangeDefault(m.id)}
                     className={cn(
-                      'flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors text-left',
-                      isSelected ?
-                        'bg-primary/10 text-primary font-medium' :
-                        'text-foreground/80 hover:bg-accent/50',
+                      'flex items-center gap-2 rounded-md px-2 py-1.5 text-xs',
+                      isDefault && !isHidden && 'bg-primary/5',
                     )}
                   >
-                    <span className="flex-1 truncate">
+                    <Switch
+                      checked={!isHidden}
+                      onCheckedChange={(checked) => {
+                        const next = checked
+                          ? hiddenModels.filter(id => id !== m.id)
+                          : [...hiddenModels, m.id]
+                        onChangeHiddenModels(next)
+                      }}
+                      className="scale-75 origin-left shrink-0"
+                    />
+                    <span className={cn(
+                      'flex-1 truncate',
+                      isHidden && 'text-muted-foreground line-through',
+                    )}
+                    >
                       {m.name}
-                      {m.isDefault ? ` (${t('createIssue.engineLabel.default')})` : ''}
                     </span>
-                    {isSelected ? <Check className="h-3 w-3 shrink-0" /> : null}
-                  </button>
+                    {isDefault
+                      ? (
+                          <span className="shrink-0 text-[10px] text-primary font-medium px-1.5 py-0.5 rounded bg-primary/10">
+                            {t('settings.default')}
+                          </span>
+                        )
+                      : !isHidden
+                          ? (
+                              <button
+                                type="button"
+                                onClick={() => onChangeDefault(m.id)}
+                                className="shrink-0 text-[10px] text-muted-foreground hover:text-foreground px-1.5 py-0.5 rounded hover:bg-accent/50 transition-colors"
+                              >
+                                {t('settings.setDefault')}
+                              </button>
+                            )
+                          : null}
+                  </div>
                 )
               })}
+
               {engine.binaryPath && (
                 <div className="mt-1 truncate border-t pt-1.5 text-[10px] font-mono text-muted-foreground/50">
                   {engine.binaryPath}
                 </div>
               )}
             </div>
-          ) :
-        null}
+          )
+        : null}
     </div>
   )
 }

--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -1315,7 +1315,13 @@ function EngineCard({
   const builtInDefault = models.find(m => m.isDefault)
   const selectedModel = savedDefault ?? builtInDefault?.id ?? ''
   const selectedModelName = models.find(m => m.id === selectedModel)?.name
-  const hiddenSet = useMemo(() => new Set(hiddenModels), [hiddenModels])
+  // Use local state for hidden models to avoid race conditions with rapid toggles.
+  // Sync from prop when server data changes (e.g. after refetch).
+  const [localHidden, setLocalHidden] = useState(hiddenModels)
+  useEffect(() => {
+    setLocalHidden(hiddenModels)
+  }, [hiddenModels])
+  const hiddenSet = useMemo(() => new Set(localHidden), [localHidden])
   const visibleModels = useMemo(
     () => models.filter(m => !hiddenSet.has(m.id)),
     [models, hiddenSet],
@@ -1430,8 +1436,9 @@ function EngineCard({
                       checked={!isHidden}
                       onCheckedChange={(checked) => {
                         const next = checked
-                          ? hiddenModels.filter(id => id !== m.id)
-                          : [...hiddenModels, m.id]
+                          ? localHidden.filter(id => id !== m.id)
+                          : [...localHidden, m.id]
+                        setLocalHidden(next)
                         onChangeHiddenModels(next)
                       }}
                       className="scale-75 origin-left shrink-0"

--- a/apps/frontend/src/components/EngineIcons.tsx
+++ b/apps/frontend/src/components/EngineIcons.tsx
@@ -68,52 +68,13 @@ export function GeminiIcon(props: IconProps) {
   )
 }
 
-/** Echo — concentric sound waves */
-export function EchoIcon(props: IconProps) {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-      <circle cx="12" cy="12" r="3" fill="currentColor" />
-      <path
-        d="M12 5a7 7 0 0 1 0 14"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        fill="none"
-        opacity="0.7"
-      />
-      <path
-        d="M12 2a10 10 0 0 1 0 20"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        fill="none"
-        opacity="0.4"
-      />
-      <path
-        d="M12 5a7 7 0 0 0 0 14"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        fill="none"
-        opacity="0.7"
-      />
-      <path
-        d="M12 2a10 10 0 0 0 0 20"
-        stroke="currentColor"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        fill="none"
-        opacity="0.4"
-      />
-    </svg>
-  )
-}
-
 const ENGINE_ICONS: Partial<Record<string, React.FC<IconProps>>> = {
   'claude-code': ClaudeIcon,
   'codex': CodexIcon,
   'acp': GeminiIcon,
-  'echo': EchoIcon,
+  'acp:gemini': GeminiIcon,
+  'acp:codex': CodexIcon,
+  'acp:claude': ClaudeIcon,
 }
 
 export function EngineIcon({ engineType, ...props }: IconProps & { engineType: string }) {

--- a/apps/frontend/src/components/issue-detail/ChatBody.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatBody.tsx
@@ -331,7 +331,6 @@ export function ChatBody({
         scrollRef={scrollRef}
         engineType={issue.engineType ?? undefined}
         model={issue.model ?? undefined}
-        externalSessionId={issue.externalSessionId ?? undefined}
         sessionStatus={issue.sessionStatus}
         statusId={issue.statusId}
         isThinking={isThinking}

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -57,7 +57,6 @@ export function ChatInput({
   scrollRef,
   engineType,
   model,
-  externalSessionId,
   sessionStatus,
   statusId,
   isThinking = false,
@@ -75,7 +74,6 @@ export function ChatInput({
   scrollRef?: React.RefObject<HTMLDivElement | null>
   engineType?: string
   model?: string
-  externalSessionId?: string
   sessionStatus?: SessionStatus | null
   statusId?: string
   isThinking?: boolean
@@ -184,7 +182,6 @@ export function ChatInput({
   const [mode, setMode] = useState<ModeOption>('auto')
   const [busyAction, setBusyAction] = useState<BusyAction>('queue')
   const activeModel = selectedModel || model || ''
-  const isModelLocked = !!externalSessionId
   const isSessionActive = sessionStatus === 'running' || sessionStatus === 'pending'
   const effectiveBusyAction: BusyAction | undefined = isSessionActive ?
     isThinking ?
@@ -315,7 +312,7 @@ export function ChatInput({
       const result = await followUp.mutateAsync({
         issueId,
         prompt,
-        model: isModelLocked ? undefined : (activeModel || undefined),
+        model: activeModel || undefined,
         permissionMode: toPermissionMode(mode),
         busyAction: effectiveBusyAction,
         files: filesToSend.length > 0 ? filesToSend : undefined,
@@ -576,8 +573,6 @@ export function ChatInput({
                     models={models}
                     value={activeModel}
                     onChange={setSelectedModel}
-                    disabled={isModelLocked}
-                    disabledTitle={isModelLocked ? t('chat.modelLockedHint') : undefined}
                   />
                 ) :
               null}
@@ -874,14 +869,10 @@ function ModelSelect({
   models,
   value,
   onChange,
-  disabled = false,
-  disabledTitle,
 }: {
   models: EngineModel[]
   value: string
   onChange: (v: string) => void
-  disabled?: boolean
-  disabledTitle?: string
 }) {
   const current = models.find(m => m.id === value)
   const displayName = current ? formatModelName(current.name || current.id) : formatModelName(value)
@@ -893,9 +884,7 @@ function ModelSelect({
           <Button
             variant="ghost"
             size="sm"
-            disabled={disabled}
-            title={disabledTitle}
-            className="h-6 px-2 text-xs text-muted-foreground gap-1 disabled:opacity-60 disabled:cursor-not-allowed"
+            className="h-6 px-2 text-xs text-muted-foreground gap-1"
           />
         )}
       >

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -573,6 +573,7 @@ export function ChatInput({
                     models={models}
                     value={activeModel}
                     onChange={setSelectedModel}
+                    disabled={isSessionActive}
                   />
                 ) :
               null}
@@ -869,10 +870,12 @@ function ModelSelect({
   models,
   value,
   onChange,
+  disabled = false,
 }: {
   models: EngineModel[]
   value: string
   onChange: (v: string) => void
+  disabled?: boolean
 }) {
   const current = models.find(m => m.id === value)
   const displayName = current ? formatModelName(current.name || current.id) : formatModelName(value)
@@ -884,7 +887,8 @@ function ModelSelect({
           <Button
             variant="ghost"
             size="sm"
-            className="h-6 px-2 text-xs text-muted-foreground gap-1"
+            disabled={disabled}
+            className="h-6 px-2 text-xs text-muted-foreground gap-1 disabled:opacity-60 disabled:cursor-not-allowed"
           />
         )}
       >

--- a/apps/frontend/src/components/issue-detail/ChatInput.tsx
+++ b/apps/frontend/src/components/issue-detail/ChatInput.tsx
@@ -29,7 +29,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Textarea } from '@/components/ui/textarea'
 import { useChangesSummary } from '@/hooks/use-changes-summary'
-import { useEngineAvailability, useFollowUpIssue } from '@/hooks/use-kanban'
+import { useEngineAvailability, useEngineSettings, useFollowUpIssue } from '@/hooks/use-kanban'
 import { formatFileSize, formatModelName } from '@/lib/format'
 import { useFileBrowserStore } from '@/stores/file-browser-store'
 import type { BusyAction, EngineModel, SessionStatus } from '@/types/kanban'
@@ -167,12 +167,15 @@ export function ChatInput({
   const changesRoot = (changesSummary as { root?: string } | null)?.root
   const openFileBrowser = useFileBrowserStore(s => s.openForIssue)
 
-  // Fetch models for current engine
+  // Fetch models for current engine, filtering out hidden ones
   const { data: discovery } = useEngineAvailability(!!engineType)
-  const models = useMemo(
-    () => (engineType ? (discovery?.models[engineType] ?? []) : []),
-    [engineType, discovery],
-  )
+  const { data: engineSettings } = useEngineSettings(!!engineType)
+  const models = useMemo(() => {
+    if (!engineType) return []
+    const all = discovery?.models[engineType] ?? []
+    const hidden = new Set(engineSettings?.engines[engineType]?.hiddenModels ?? [])
+    return hidden.size > 0 ? all.filter(m => !hidden.has(m.id)) : all
+  }, [engineType, discovery, engineSettings])
   const [selectedModel, setSelectedModel] = useState(model || '')
   // Sync selectedModel when issue changes (model prop changes)
   useEffect(() => {
@@ -898,7 +901,7 @@ function ModelSelect({
       >
         <span className="truncate max-w-[140px]">{displayName}</span>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" side="top" className="min-w-[180px] text-xs">
+      <DropdownMenuContent align="end" side="top" className="min-w-[180px] max-h-[320px] overflow-y-auto text-xs">
         {models.map(m => (
           <DropdownMenuItem
             key={m.id}

--- a/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
+++ b/apps/frontend/src/components/kanban/CreateIssueDialog.tsx
@@ -20,6 +20,7 @@ import {
   useEngineSettings,
   useProject,
 } from '@/hooks/use-kanban'
+import { formatModelName } from '@/lib/format'
 import { tStatus } from '@/lib/i18n-utils'
 import type { StatusDefinition } from '@/lib/statuses'
 import { STATUSES } from '@/lib/statuses'
@@ -89,11 +90,13 @@ export function CreateIssueForm({
     return installedEngines[0]?.engineType ?? ''
   }, [engineType, engineSettings, installedEngines])
 
-  // Models for the resolved engine
+  // Models for the resolved engine, filtering out hidden ones
   const currentModels = useMemo(() => {
     const models = discovery?.models ?? {}
-    return resolvedEngineType ? (models[resolvedEngineType] ?? []) : []
-  }, [resolvedEngineType, discovery?.models])
+    const all = resolvedEngineType ? (models[resolvedEngineType] ?? []) : []
+    const hidden = new Set(engineSettings?.engines[resolvedEngineType]?.hiddenModels ?? [])
+    return hidden.size > 0 ? all.filter(m => !hidden.has(m.id)) : all
+  }, [resolvedEngineType, discovery?.models, engineSettings])
 
   // When engine changes, reset model to "default" (system auto)
   const handleEngineChange = useCallback((newEngine: string) => {
@@ -446,11 +449,11 @@ function ModelSelect({
         )}
       >
         <span className="truncate">
-          {isDefault ? t('createIssue.modelDefault') : (current?.name ?? '—')}
+          {isDefault ? t('createIssue.modelDefault') : (current ? formatModelName(current.name || current.id) : '—')}
         </span>
         <ChevronDown className="h-3 w-3 text-muted-foreground ml-auto shrink-0" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-[220px]">
+      <DropdownMenuContent align="start" className="min-w-[220px] max-h-[320px] overflow-y-auto">
         <DropdownMenuItem onSelect={() => onChange('')} className={isDefault ? 'bg-accent/50' : ''}>
           <span className="font-medium">{t('createIssue.modelDefault')}</span>
           <span className="text-[10px] text-muted-foreground ml-1">
@@ -465,16 +468,18 @@ function ModelSelect({
             onSelect={() => onChange(m.id)}
             className={m.id === value ? 'bg-accent/50' : ''}
           >
-            <span className="font-medium">{m.name}</span>
-            {m.isDefault ?
-                (
+            <span className="font-medium">
+              {formatModelName(m.name || m.id)}
+            </span>
+            {m.isDefault
+              ? (
                   <span className="text-[10px] text-muted-foreground ml-1">
                     (
                     {t('createIssue.engineLabel.default')}
                     )
                   </span>
-                ) :
-              null}
+                )
+              : null}
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -468,6 +468,19 @@ export function useUpdateEngineModelSetting() {
   })
 }
 
+export function useUpdateEngineHiddenModels() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (args: { engineType: string, hiddenModels: string[] }) =>
+      kanbanApi.updateEngineHiddenModels(args.engineType, {
+        hiddenModels: args.hiddenModels,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.engineSettings() })
+    },
+  })
+}
+
 export function useUpdateDefaultEngine() {
   const queryClient = useQueryClient()
   return useMutation({

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -128,16 +128,14 @@
       "coder": "Coder",
       "planner": "Planner",
       "reviewer": "Reviewer",
-      "researcher": "Researcher",
-      "echo": "Echo"
+      "researcher": "Researcher"
     },
     "engineDesc": {
       "default": "Auto assign",
       "coder": "Write code",
       "planner": "Plan tasks",
       "reviewer": "Review code",
-      "researcher": "Research",
-      "echo": "Mock engine, does nothing"
+      "researcher": "Research"
     },
     "modelDesc": {
       "opus": "Most capable",
@@ -284,6 +282,10 @@
     "version": "v{{version}}",
     "models": "{{count}} models",
     "defaultModel": "Default Model",
+    "availableModels": "Available Models",
+    "default": "Default",
+    "setDefault": "Set default",
+    "modelHidden": "Hidden",
     "probe": "Refresh",
     "probing": "Detecting engines...",
     "workspacePath": "Default Workspace Path",

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -176,7 +176,6 @@
     "plugins": "Plugins",
     "pluginSearch": "Search plugins...",
     "noPlugins": "No matching plugins",
-    "modelLockedHint": "Model is locked for this session. Restart to change it.",
     "refreshLogs": "Refresh logs",
     "worktree": "Worktree",
     "worktreeBranch": "Branch",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -176,7 +176,6 @@
     "plugins": "Plugins",
     "pluginSearch": "搜索插件...",
     "noPlugins": "没有匹配的插件",
-    "modelLockedHint": "当前会话已锁定模型，如需切换请重启会话。",
     "refreshLogs": "刷新日志",
     "worktree": "工作树",
     "worktreeBranch": "分支",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -128,16 +128,14 @@
       "coder": "Coder",
       "planner": "Planner",
       "reviewer": "Reviewer",
-      "researcher": "Researcher",
-      "echo": "Echo"
+      "researcher": "Researcher"
     },
     "engineDesc": {
       "default": "自动分配",
       "coder": "编写代码",
       "planner": "规划任务",
       "reviewer": "审查代码",
-      "researcher": "调研分析",
-      "echo": "模拟模型，不做任何工作"
+      "researcher": "调研分析"
     },
     "modelDesc": {
       "opus": "最强大",
@@ -284,6 +282,10 @@
     "version": "v{{version}}",
     "models": "{{count}} 个模型",
     "defaultModel": "默认模型",
+    "availableModels": "可用模型",
+    "default": "默认",
+    "setDefault": "设为默认",
+    "modelHidden": "已隐藏",
     "probe": "刷新",
     "probing": "正在检测引擎...",
     "workspacePath": "默认工作区路径",

--- a/apps/frontend/src/lib/format.ts
+++ b/apps/frontend/src/lib/format.ts
@@ -6,10 +6,10 @@ export function formatFileSize(bytes: number): string {
 
 /** Turn a raw model ID like "claude-opus-4-6" into a shorter display name */
 export function formatModelName(id: string): string {
-  const acpMatch = id.match(/^acp:([\w-]+):(.+)$/i)
+  // Strip ACP agent prefix for display (e.g. "acp:gemini:model" → format "model")
+  const acpMatch = id.match(/^acp:[\w-]+:(.+)$/i)
   if (acpMatch) {
-    const agentName = acpMatch[1].charAt(0).toUpperCase() + acpMatch[1].slice(1)
-    return `${agentName} / ${formatModelName(acpMatch[2])}`
+    return formatModelName(acpMatch[1])
   }
 
   const m = id.match(/^claude-(opus|sonnet|haiku)-(\d+)-(\d+)(\[.*\])?$/)

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -258,6 +258,11 @@ export const kanbanApi = {
     patch<{ defaultEngine: string }>('/api/engines/default-engine', {
       defaultEngine,
     }),
+  updateEngineHiddenModels: (engineType: string, data: { hiddenModels: string[] }) =>
+    patch<{ engineType: string, hiddenModels: string[] }>(
+      `/api/engines/${encodeURIComponent(engineType)}/hidden-models`,
+      data,
+    ),
   probeEngines: () => post<ProbeResult>('/api/engines/probe', {}),
 
   // App Settings

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,7 +17,7 @@ export interface Project {
   updatedAt: string
 }
 
-export type EngineType = 'claude-code' | 'codex' | 'acp' | 'echo'
+export type EngineType = 'claude-code' | 'codex' | 'acp' | `acp:${string}`
 
 export interface PluginInfo { name: string, path: string }
 
@@ -297,7 +297,7 @@ export interface EngineProfile {
 
 export interface EngineSettings {
   defaultEngine: string | null
-  engines: Record<string, { defaultModel?: string }>
+  engines: Record<string, { defaultModel?: string, hiddenModels?: string[] }>
 }
 
 export interface ProbeResult {


### PR DESCRIPTION
## Summary
- Split single ACP engine into virtual per-agent engines (`acp:gemini`, `acp:codex`, `acp:claude`) — each appears as a top-level engine in the UI with its own icon, default model, and model list
- Add model toggle (enable/disable) in engine settings — disabled models are hidden from chat model selectors
- Merge "Default Model" and "Available Models" into a unified settings list with switch toggles and "set default" buttons
- Remove Echo engine globally since ACP now exists
- Unlock model switching during follow-up sessions — models can be changed freely without restart
- Stop auto-filling default model into DB — let engine CLIs decide their own defaults when model is `auto` or unset

## Changes
- **Backend**: `expandAcpEngines()` in startup-probe, registry `acp:*` resolution, hidden models DB helpers, Zod schema updates
- **Backend**: Restrict ACP type validation to known agent IDs (gemini/codex/claude) only
- **Backend**: Remove `isFollowUpModelChangeBlocked` — allow model switching during sessions
- **Backend**: Treat `auto` model as unset across all execution paths (execute, follow-up, retry) and all executors (Claude, Codex, ACP)
- **Frontend**: unified model settings UI, flat model selectors, per-agent engine icons, i18n updates
- **Frontend**: Fix hidden-model toggle race condition with local optimistic state
- **Removed**: Echo engine (type, executor registration, profiles, icons, i18n keys)
- **Removed**: Model lock UI (`isModelLocked`, `modelLockedHint`)

## Test plan
- [ ] Verify ACP engines appear as separate entries in engine selector
- [ ] Verify selecting `acp:claude` spawns the correct agent binary
- [ ] Verify model toggle hides/shows models in chat input
- [ ] Verify setting default model per engine works
- [ ] Verify Echo engine no longer appears anywhere in the UI
- [ ] Verify model can be switched during follow-up without restart
- [ ] Verify `auto` model does not pass `--model` flag to engine CLIs
- [ ] Run `bun run lint` and `bun run build` — both pass