### PR TITLE
feat: global process monitor with project grouping

### DIFF
--- a/apps/api/src/engines/issue/constants.ts
+++ b/apps/api/src/engines/issue/constants.ts
@@ -9,7 +9,7 @@ export const MAX_AUTO_RETRIES = 1
 //   T+6m: no response after interrupt — force kill
 export const GC_INTERVAL_MS = 60 * 1000 // 1 minute — frequent stall detection
 export const MAX_CONCURRENT_EXECUTIONS = Number(process.env.MAX_CONCURRENT_EXECUTIONS) || 5
-export const IDLE_TIMEOUT_MS = 30 * 60 * 1000 // 30 minutes
+export const IDLE_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 export const STREAM_STALL_TIMEOUT_MS = 2 * 60 * 1000 // 2 minutes — check process liveness (non-destructive)
 export const STALL_LIVENESS_GRACE_MS = 2 * 60 * 1000 // 2 minutes — wait for CLI internal retry before sending interrupt
 export const STALL_INTERRUPT_GRACE_MS = 2 * 60 * 1000 // 2 minutes — kill process if no response after interrupt

--- a/apps/api/src/routes/api.ts
+++ b/apps/api/src/routes/api.ts
@@ -17,8 +17,8 @@ apiRoutes.route('/projects', projects)
 apiRoutes.route('/projects/:projectId/issues', issues)
 apiRoutes.route('/issues/review', reviewIssues)
 apiRoutes.route('/files', files)
-apiRoutes.route('/projects/:projectId/processes', processes)
 apiRoutes.route('/projects/:projectId/worktrees', worktrees)
+apiRoutes.route('/processes', processes)
 
 // Infrastructure routes
 apiRoutes.route('/filesystem', filesystem)

--- a/apps/api/src/routes/processes.ts
+++ b/apps/api/src/routes/processes.ts
@@ -1,96 +1,88 @@
 import { and, eq, inArray } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { db } from '@/db'
-import { findProject } from '@/db/helpers'
-import { issues as issuesTable } from '@/db/schema'
+import { issues as issuesTable, projects as projectsTable } from '@/db/schema'
 import { issueEngine } from '@/engines/issue'
 import { getPidFromManaged } from '@/engines/issue/utils/pid'
 import { logger } from '@/logger'
+import type { ProcessInfo } from '@bkd/shared'
 
-const processes = new Hono()
-
-processes.get('/', async (c) => {
-  const projectId = c.req.param('projectId')!
-  const project = await findProject(projectId)
-  if (!project) {
-    return c.json({ success: false, error: 'Project not found' }, 404)
-  }
-
+async function buildProcessInfoList(): Promise<ProcessInfo[]> {
   const activeProcesses = issueEngine.getActiveProcesses()
   const issueIds = activeProcesses.map(p => p.issueId)
+  if (issueIds.length === 0) return []
 
-  // Build result from in-memory active processes (PM is the source of truth)
-  const result: Array<{
-    executionId: string
-    issueId: string
-    issueTitle: string
-    issueNumber: number
-    engineType: string
-    processState: string
-    model: string | null
-    startedAt: string
-    turnInFlight: boolean
-    spawnCommand: string | null
-    lastIdleAt: string | null
-    pid: number | null
-  }> = []
-
-  if (issueIds.length > 0) {
-    const projectIssues = await db
-      .select()
-      .from(issuesTable)
-      .where(
-        and(
-          eq(issuesTable.projectId, project.id),
-          eq(issuesTable.isDeleted, 0),
-          inArray(issuesTable.id, issueIds),
-        ),
-      )
-
-    const issueMap = new Map(projectIssues.map(i => [i.id, i]))
-
-    for (const p of activeProcesses) {
-      const issue = issueMap.get(p.issueId)
-      if (!issue) continue
-      result.push({
-        executionId: p.executionId,
-        issueId: p.issueId,
-        issueTitle: issue.title,
-        issueNumber: issue.issueNumber,
-        engineType: p.engineType,
-        processState: p.state,
-        model: issue.model ?? null,
-        startedAt: p.startedAt.toISOString(),
-        turnInFlight: p.turnInFlight,
-        spawnCommand: p.spawnCommand ?? null,
-        lastIdleAt: p.lastIdleAt?.toISOString() ?? null,
-        pid: getPidFromManaged(p) ?? null,
-      })
-    }
-  }
-
-  // Process state comes entirely from PM memory. DB-only stale entries
-  // (running/pending with no active process) are cleaned by the reconciler.
-  return c.json({ success: true, data: { processes: result } })
-})
-
-// POST /api/projects/:projectId/processes/:issueId/terminate
-processes.post('/:issueId/terminate', async (c) => {
-  const projectId = c.req.param('projectId')!
-  const project = await findProject(projectId)
-  if (!project) {
-    return c.json({ success: false, error: 'Project not found' }, 404)
-  }
-
-  const issueId = c.req.param('issueId')!
-  const [issue] = await db
+  const matchedIssues = await db
     .select()
     .from(issuesTable)
     .where(
       and(
-        eq(issuesTable.id, issueId),
-        eq(issuesTable.projectId, project.id),
         eq(issuesTable.isDeleted, 0),
+        inArray(issuesTable.id, issueIds),
+      ),
+    )
+
+  if (matchedIssues.length === 0) return []
+
+  const projectIds = [...new Set(matchedIssues.map(i => i.projectId))]
+  const projects = await db
+    .select({ id: projectsTable.id, name: projectsTable.name })
+    .from(projectsTable)
+    .where(
+      and(
+        inArray(projectsTable.id, projectIds),
+        eq(projectsTable.isDeleted, 0),
+      ),
+    )
+  const projectMap = new Map(projects.map(p => [p.id, p.name]))
+
+  const issueMap = new Map(matchedIssues.map(i => [i.id, i]))
+  const result: ProcessInfo[] = []
+
+  for (const p of activeProcesses) {
+    const issue = issueMap.get(p.issueId)
+    if (!issue) continue
+    result.push({
+      executionId: p.executionId,
+      issueId: p.issueId,
+      issueTitle: issue.title,
+      issueNumber: issue.issueNumber,
+      projectId: issue.projectId,
+      projectName: projectMap.get(issue.projectId) ?? '',
+      engineType: p.engineType,
+      processState: p.state,
+      model: issue.model ?? null,
+      startedAt: p.startedAt.toISOString(),
+      turnInFlight: p.turnInFlight,
+      spawnCommand: p.spawnCommand ?? null,
+      lastIdleAt: p.lastIdleAt?.toISOString() ?? null,
+      pid: getPidFromManaged(p) ?? null,
+    })
+  }
+
+  return result
+}
+
+const processes = new Hono()
+
+processes.get('/', async (c) => {
+  const result = await buildProcessInfoList()
+  return c.json({ success: true, data: { processes: result } })
+})
+
+processes.post('/:issueId/terminate', async (c) => {
+  const issueId = c.req.param('issueId')!
+
+  // Verify issue exists and its project is not deleted
+  const [issue] = await db
+    .select({ id: issuesTable.id, projectId: issuesTable.projectId })
+    .from(issuesTable)
+    .innerJoin(projectsTable, eq(issuesTable.projectId, projectsTable.id))
+    .where(
+      and(
+        eq(issuesTable.id, issueId),
+        eq(issuesTable.isDeleted, 0),
+        eq(projectsTable.isDeleted, 0),
       ),
     )
 

--- a/apps/api/src/routes/processes.ts
+++ b/apps/api/src/routes/processes.ts
@@ -26,7 +26,7 @@ async function buildProcessInfoList(): Promise<ProcessInfo[]> {
 
   const projectIds = [...new Set(matchedIssues.map(i => i.projectId))]
   const projects = await db
-    .select({ id: projectsTable.id, name: projectsTable.name })
+    .select({ id: projectsTable.id, alias: projectsTable.alias, name: projectsTable.name })
     .from(projectsTable)
     .where(
       and(
@@ -34,7 +34,7 @@ async function buildProcessInfoList(): Promise<ProcessInfo[]> {
         eq(projectsTable.isDeleted, 0),
       ),
     )
-  const projectMap = new Map(projects.map(p => [p.id, p.name]))
+  const projectMap = new Map(projects.map(p => [p.id, { alias: p.alias, name: p.name }]))
 
   const issueMap = new Map(matchedIssues.map(i => [i.id, i]))
   const result: ProcessInfo[] = []
@@ -48,7 +48,8 @@ async function buildProcessInfoList(): Promise<ProcessInfo[]> {
       issueTitle: issue.title,
       issueNumber: issue.issueNumber,
       projectId: issue.projectId,
-      projectName: projectMap.get(issue.projectId) ?? '',
+      projectAlias: projectMap.get(issue.projectId)?.alias ?? '',
+      projectName: projectMap.get(issue.projectId)?.name ?? '',
       engineType: p.engineType,
       processState: p.state,
       model: issue.model ?? null,

--- a/apps/frontend/src/components/issue-detail/IssueListPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueListPanel.tsx
@@ -111,7 +111,7 @@ export function IssueListPanel({
             variant="ghost"
             size="icon"
             className="h-7 w-7 text-muted-foreground hover:text-foreground"
-            onClick={() => toggleProcessManager(projectId)}
+            onClick={() => toggleProcessManager()}
             aria-label={t('processManager.title')}
             title={t('processManager.title')}
           >

--- a/apps/frontend/src/components/kanban/KanbanHeader.tsx
+++ b/apps/frontend/src/components/kanban/KanbanHeader.tsx
@@ -58,7 +58,7 @@ export function KanbanHeader({
           )}
           <button
             type="button"
-            onClick={() => toggleProcessManager(project.alias)}
+            onClick={() => toggleProcessManager()}
             className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-foreground/[0.07] transition-colors shrink-0"
             aria-label={t('processManager.title')}
             title={t('processManager.title')}

--- a/apps/frontend/src/components/processes/ProcessList.tsx
+++ b/apps/frontend/src/components/processes/ProcessList.tsx
@@ -79,7 +79,7 @@ function ProcessCard({ proc }: { proc: ProcessInfo }) {
         <button
           type="button"
           className="text-xs font-medium text-foreground truncate hover:underline cursor-pointer text-left min-w-0"
-          onClick={() => navigate(`/projects/${proc.projectId}/issues/${proc.issueId}`)}
+          onClick={() => navigate(`/projects/${proc.projectAlias}/issues/${proc.issueId}`)}
         >
           <span className="text-muted-foreground">
             #

--- a/apps/frontend/src/components/processes/ProcessList.tsx
+++ b/apps/frontend/src/components/processes/ProcessList.tsx
@@ -1,7 +1,5 @@
 import {
   Activity,
-  ChevronDown,
-  ChevronRight,
   CircleAlert,
   CircleCheck,
   CirclePause,
@@ -11,12 +9,12 @@ import {
   Square,
   Terminal,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { useTerminateProcess } from '@/hooks/use-kanban'
+import { useTerminateProcessGlobal } from '@/hooks/use-kanban'
 import type { ProcessInfo } from '@/types/kanban'
 
 function StatusIcon({ status }: { status: string | null }) {
@@ -66,10 +64,10 @@ function isIdle(proc: ProcessInfo): boolean {
   return !proc.turnInFlight && !!proc.lastIdleAt
 }
 
-function ProcessCard({ proc, projectId }: { proc: ProcessInfo, projectId: string }) {
+function ProcessCard({ proc }: { proc: ProcessInfo }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const terminateMutation = useTerminateProcess(projectId)
+  const terminateMutation = useTerminateProcessGlobal()
   const [showCommand, setShowCommand] = useState(false)
   const idle = isIdle(proc)
 
@@ -81,7 +79,7 @@ function ProcessCard({ proc, projectId }: { proc: ProcessInfo, projectId: string
         <button
           type="button"
           className="text-xs font-medium text-foreground truncate hover:underline cursor-pointer text-left min-w-0"
-          onClick={() => navigate(`/projects/${projectId}/issues/${proc.issueId}`)}
+          onClick={() => navigate(`/projects/${proc.projectId}/issues/${proc.issueId}`)}
         >
           <span className="text-muted-foreground">
             #
@@ -145,13 +143,6 @@ function ProcessCard({ proc, projectId }: { proc: ProcessInfo, projectId: string
             className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground cursor-pointer"
             onClick={() => setShowCommand(v => !v)}
           >
-            {showCommand ?
-                (
-                  <ChevronDown className="h-3 w-3" />
-                ) :
-                (
-                  <ChevronRight className="h-3 w-3" />
-                )}
             <Terminal className="h-3 w-3" />
             {t('processManager.command')}
           </button>
@@ -180,17 +171,48 @@ function ProcessCard({ proc, projectId }: { proc: ProcessInfo, projectId: string
   )
 }
 
-export function ProcessList({
-  processes,
-  projectId,
-}: {
-  processes: ProcessInfo[]
-  projectId: string
-}) {
+export function ProcessList({ processes }: { processes: ProcessInfo[] }) {
+  // Group processes by project
+  const grouped = useMemo(() => {
+    const map = new Map<string, { projectName: string, projectId: string, items: ProcessInfo[] }>()
+    for (const proc of processes) {
+      let group = map.get(proc.projectId)
+      if (!group) {
+        group = { projectName: proc.projectName, projectId: proc.projectId, items: [] }
+        map.set(proc.projectId, group)
+      }
+      group.items.push(proc)
+    }
+    return [...map.values()]
+  }, [processes])
+
+  // If only one project, skip the group header
+  if (grouped.length === 1) {
+    return (
+      <div className="flex flex-col gap-2">
+        {grouped[0]!.items.map(proc => (
+          <ProcessCard key={proc.executionId} proc={proc} />
+        ))}
+      </div>
+    )
+  }
+
   return (
-    <div className="flex flex-col gap-2">
-      {processes.map(proc => (
-        <ProcessCard key={proc.issueId} proc={proc} projectId={projectId} />
+    <div className="flex flex-col gap-4">
+      {grouped.map(group => (
+        <div key={group.projectId}>
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-xs font-medium text-muted-foreground">{group.projectName}</span>
+            <span className="inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-full bg-muted text-muted-foreground text-[10px] font-medium">
+              {group.items.length}
+            </span>
+          </div>
+          <div className="flex flex-col gap-2">
+            {group.items.map(proc => (
+              <ProcessCard key={proc.executionId} proc={proc} />
+            ))}
+          </div>
+        </div>
       ))}
     </div>
   )

--- a/apps/frontend/src/components/processes/ProcessManagerDrawer.tsx
+++ b/apps/frontend/src/components/processes/ProcessManagerDrawer.tsx
@@ -1,7 +1,7 @@
 import { Activity, Maximize2, Minimize2, Minus, X } from 'lucide-react'
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useProject, useProjectProcesses } from '@/hooks/use-kanban'
+import { useAllProcesses } from '@/hooks/use-kanban'
 import { useIsMobile } from '@/hooks/use-mobile'
 import {
   PROCESS_MANAGER_MAX_WIDTH_RATIO,
@@ -12,15 +12,14 @@ import { ProcessList } from './ProcessList'
 
 export function ProcessManagerDrawer() {
   const { t } = useTranslation()
-  const { isOpen, isFullscreen, width, projectId, close, minimize, toggleFullscreen, setWidth } =
+  const { isOpen, isFullscreen, width, close, minimize, toggleFullscreen, setWidth } =
     useProcessManagerStore()
   const isMobile = useIsMobile()
   const dragRef = useRef<{ startX: number, startWidth: number } | null>(null)
 
-  const { data: project } = useProject(projectId ?? '')
-  const { data, isLoading } = useProjectProcesses(projectId ?? '', !!projectId && isOpen)
+  const { data, isLoading } = useAllProcesses(isOpen)
 
-  if (!isOpen || !projectId) return null
+  if (!isOpen) return null
 
   const viewportWidth = typeof window === 'undefined' ? 1024 : window.innerWidth
   const maxWidth = Math.round(viewportWidth * PROCESS_MANAGER_MAX_WIDTH_RATIO)
@@ -88,9 +87,9 @@ export function ProcessManagerDrawer() {
           <div className="flex items-center gap-2 min-w-0">
             <Activity className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
             <span className="text-xs font-medium text-muted-foreground truncate">
-              {project?.name ?? t('processManager.title')}
+              {t('processManager.title')}
             </span>
-            {processes.length > 0 && <Badge count={processes.length} />}
+            {processes.length > 0 && <CountBadge count={processes.length} />}
           </div>
           <div className="flex items-center gap-1">
             <button
@@ -150,7 +149,7 @@ export function ProcessManagerDrawer() {
                   </div>
                 ) :
                 (
-                  <ProcessList processes={processes} projectId={projectId} />
+                  <ProcessList processes={processes} />
                 )}
         </div>
       </div>
@@ -158,7 +157,7 @@ export function ProcessManagerDrawer() {
   )
 }
 
-function Badge({ count }: { count: number }) {
+function CountBadge({ count }: { count: number }) {
   return (
     <span className="inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-full bg-primary text-primary-foreground text-[10px] font-medium">
       {count}

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -868,6 +868,10 @@ export function useTerminateProcessGlobal() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.allProcesses(),
       })
+      // Refresh issue status on kanban boards after termination
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.projects(),
+      })
     },
   })
 }

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -23,7 +23,7 @@ export const queryKeys = {
     ['projects', projectId, 'issues', issueId, 'slash-commands'] as const,
   projectFiles: (root: string | null, path: string, hideIgnored: boolean) =>
     ['files', root, path, { hideIgnored }] as const,
-  projectProcesses: (projectId: string) => ['projects', projectId, 'processes'] as const,
+  allProcesses: () => ['processes', 'all'] as const,
   projectWorktrees: (projectId: string) => ['projects', projectId, 'worktrees'] as const,
   logPageSize: () => ['settings', 'logPageSize'] as const,
   worktreeAutoCleanup: () => ['settings', 'worktreeAutoCleanup'] as const,
@@ -394,7 +394,7 @@ export function useCancelIssue(projectId: string) {
         queryKey: queryKeys.issues(projectId),
       })
       queryClient.invalidateQueries({
-        queryKey: queryKeys.projectProcesses(projectId),
+        queryKey: queryKeys.allProcesses(),
       })
     },
   })
@@ -851,28 +851,22 @@ export function useSaveFile() {
 
 // --- Process Manager hooks ---
 
-export function useProjectProcesses(projectId: string, enabled = true) {
+export function useAllProcesses(enabled = true) {
   return useQuery({
-    queryKey: queryKeys.projectProcesses(projectId),
-    queryFn: () => kanbanApi.getProjectProcesses(projectId),
-    enabled: !!projectId && enabled,
+    queryKey: queryKeys.allProcesses(),
+    queryFn: () => kanbanApi.getAllProcesses(),
+    enabled,
     refetchInterval: 5000,
   })
 }
 
-export function useTerminateProcess(projectId: string) {
+export function useTerminateProcessGlobal() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (issueId: string) => kanbanApi.terminateProcess(projectId, issueId),
-    onSuccess: (_data, issueId) => {
+    mutationFn: (issueId: string) => kanbanApi.terminateProcess(issueId),
+    onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: queryKeys.projectProcesses(projectId),
-      })
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.issue(projectId, issueId),
-      })
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.issues(projectId),
+        queryKey: queryKeys.allProcesses(),
       })
     },
   })

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -461,12 +461,12 @@ export const kanbanApi = {
   },
 
   // Process Manager
-  getProjectProcesses: (projectId: string) =>
-    get<ProjectProcessesResponse>(`/api/projects/${projectId}/processes`),
+  getAllProcesses: () =>
+    get<ProjectProcessesResponse>('/api/processes'),
 
-  terminateProcess: (projectId: string, issueId: string) =>
+  terminateProcess: (issueId: string) =>
     post<{ issueId: string, status: string }>(
-      `/api/projects/${projectId}/processes/${issueId}/terminate`,
+      `/api/processes/${issueId}/terminate`,
       {},
     ),
 

--- a/apps/frontend/src/stores/process-manager-store.ts
+++ b/apps/frontend/src/stores/process-manager-store.ts
@@ -19,10 +19,9 @@ interface ProcessManagerStore {
   isMinimized: boolean
   isFullscreen: boolean
   width: number
-  projectId: string | null
-  open: (projectId: string) => void
+  open: () => void
   close: () => void
-  toggle: (projectId: string) => void
+  toggle: () => void
   minimize: () => void
   restore: () => void
   toggleFullscreen: () => void
@@ -37,15 +36,14 @@ export const useProcessManagerStore = create<ProcessManagerStore>(set => ({
   isMinimized: false,
   isFullscreen: false,
   width: Math.round(getViewportWidth() * DEFAULT_WIDTH_RATIO),
-  projectId: null,
 
-  open: projectId => set({ isOpen: true, isMinimized: false, projectId }),
+  open: () => set({ isOpen: true, isMinimized: false }),
   close: () => set({ isOpen: false }),
-  toggle: projectId =>
+  toggle: () =>
     set((s) => {
-      if (s.isMinimized) return { isOpen: true, isMinimized: false, projectId }
-      if (s.isOpen && s.projectId === projectId) return { isOpen: false }
-      return { isOpen: true, projectId }
+      if (s.isMinimized) return { isOpen: true, isMinimized: false }
+      if (s.isOpen) return { isOpen: false }
+      return { isOpen: true }
     }),
   minimize: () => set({ isOpen: false, isMinimized: true, isFullscreen: false }),
   restore: () => set({ isOpen: true, isMinimized: false }),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -377,6 +377,8 @@ export interface ProcessInfo {
   issueId: string
   issueTitle: string
   issueNumber: number
+  projectId: string
+  projectName: string
   engineType: string
   processState: string
   model: string | null

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -378,6 +378,7 @@ export interface ProcessInfo {
   issueTitle: string
   issueNumber: number
   projectId: string
+  projectAlias: string
   projectName: string
   engineType: string
   processState: string


### PR DESCRIPTION
## Summary
- Replace project-scoped process API with global `/api/processes` endpoint
- Process manager drawer now shows all processes across projects, grouped by project name
- Reduce idle timeout from 30 minutes to 5 minutes for cost control
- Clean up UI: remove chevron arrows from command toggle

## Changes
- **Backend**: Single global `/api/processes` route with `isDeleted` filtering and project ownership validation on terminate
- **Shared types**: `ProcessInfo` gains `projectId` and `projectName` fields
- **Frontend**: Drawer fetches all processes globally, groups by project; simplified store (no `projectId` dependency)
- **Constants**: `IDLE_TIMEOUT_MS` reduced from 30min to 5min

## Test plan
- [ ] Open process manager from any project — verify all active processes appear grouped by project
- [ ] With processes in multiple projects — verify project group headers display correctly
- [ ] With processes in a single project — verify no redundant group header
- [ ] Terminate a process — verify it disappears from the list
- [ ] Verify idle processes are auto-terminated after 5 minutes
- [ ] Verify command toggle shows without chevron arrow