### PR TITLE
feat: enhance MCP tools with workflow guidance and process monitoring

### DIFF
--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -11,7 +11,7 @@ import { db } from '@/db'
 import { findProject, getAppSetting, getDefaultEngine, getEngineDefaultModel, getServerUrl } from '@/db/helpers'
 import { issues as issuesTable, projects as projectsTable } from '@/db/schema'
 import { issueEngine } from '@/engines/issue'
-import { getLogsFromDb } from '@/engines/issue/persistence/queries'
+import { getLogsFromDb, getNextTurnIndex } from '@/engines/issue/persistence/queries'
 import { engineRegistry } from '@/engines/executors'
 import { getEngineDiscovery } from '@/engines/startup-probe'
 import type { EngineType } from '@/engines/types'
@@ -21,8 +21,11 @@ import {
   ensureWorking,
   flushPendingAsFollowUp,
   parseProjectEnvVars,
+  parseTags,
+  serializeTags,
   triggerIssueExecution,
 } from '@/routes/issues/_shared'
+import { buildProcessInfoList } from '@/routes/processes'
 import { toISO } from '@/utils/date'
 import { buildIssueUrl, dispatch as webhookDispatch } from '@/webhooks/dispatcher'
 
@@ -55,6 +58,7 @@ function serializeIssue(row: typeof issuesTable.$inferSelect) {
     statusId: row.statusId,
     issueNumber: row.issueNumber,
     title: row.title,
+    tags: parseTags(row.tag),
     engineType: row.engineType ?? null,
     sessionStatus: row.sessionStatus ?? null,
     model: row.model ?? null,
@@ -150,9 +154,11 @@ async function insertIssueInTransaction(
     engineType: string | null
     model: string | null
     sessionStatus: string | null
+    useWorktree?: boolean
+    tags?: string[]
   },
 ) {
-  const { statusId, title, engineType, model, sessionStatus } = opts
+  const { statusId, title, engineType, model, sessionStatus, useWorktree, tags } = opts
 
   const [newIssue] = await db.transaction(async (tx) => {
     const [maxNumRow] = await tx
@@ -187,6 +193,8 @@ async function insertIssueInTransaction(
         model,
         sessionStatus,
         prompt: title,
+        useWorktree: useWorktree ?? false,
+        tag: serializeTags(tags),
       })
       .returning()
   })
@@ -345,15 +353,25 @@ export function createMcpServer(): McpServer {
 
   server.registerTool('create-issue', {
     title: 'Create Issue',
-    description: 'Create a new issue (task) in a project. Set statusId to "working" to auto-execute with an AI engine.',
+    description: [
+      'Create a new issue (task) in a project. Set statusId to "working" to auto-execute with an AI engine.',
+      '',
+      'Best practices:',
+      '- Use a SHORT, concise title (e.g. "fix login bug", "add dark mode"). Do NOT put detailed requirements in the title.',
+      '- After creating the issue, use follow-up-issue to send detailed requirements, context, and instructions.',
+      '- For complex tasks involving multiple files or large changes, set useWorktree=true for isolated execution.',
+      '- Check list-processes before creating working issues to monitor system workload.',
+    ].join('\n'),
     inputSchema: z.object({
       projectId: z.string().describe('Project ID or alias'),
-      title: z.string().min(1).max(500).describe('Issue title / prompt for the AI agent'),
+      title: z.string().min(1).max(500).describe('Short, concise issue title (e.g. "fix auth bug"). Send detailed requirements via follow-up-issue after creation.'),
       statusId: z.enum(['todo', 'working', 'review', 'done']).describe('Initial status. Use "working" to auto-execute.'),
-      engineType: z.enum(['claude-code', 'codex', 'acp', 'echo']).optional().describe('AI engine type. Defaults to server setting.'),
+      engineType: z.enum(['claude-code', 'codex']).optional().describe('AI engine type. Defaults to server setting.'),
       model: z.string().optional().describe('Model ID. Defaults to engine default.'),
+      useWorktree: z.boolean().optional().describe('If true, execute in an isolated git worktree. Recommended for complex multi-file changes.'),
+      tags: z.array(z.string().max(50)).max(10).optional().describe('Tags for grouping issues (max 10 tags, each max 50 chars).'),
     }),
-  }, async ({ projectId, title, statusId, engineType, model }) => {
+  }, async ({ projectId, title, statusId, engineType, model, useWorktree, tags }) => {
     const project = await findProject(projectId)
     if (!project) return errorResult('Project not found')
 
@@ -367,6 +385,8 @@ export function createMcpServer(): McpServer {
       engineType: resolved.engine,
       model: resolved.model,
       sessionStatus: shouldExecute ? 'pending' : null,
+      useWorktree,
+      tags,
     })
 
     // Dispatch webhook (mirrors routes/issues/create.ts)
@@ -403,14 +423,22 @@ export function createMcpServer(): McpServer {
 
   server.registerTool('update-issue', {
     title: 'Update Issue',
-    description: 'Update an issue\'s title, status, or other fields. Moving to "working" triggers AI execution.',
+    description: [
+      'Update an issue\'s title, status, or other fields. Moving to "working" triggers AI execution.',
+      '',
+      'Completion workflow:',
+      '- When a task is finished, move to "review" (not "done") to await human confirmation.',
+      '- Only move to "done" after human review and approval.',
+      '- For git repos, ensure changes are committed by feature/function before moving to review.',
+    ].join('\n'),
     inputSchema: z.object({
       projectId: z.string().describe('Project ID or alias'),
       issueId: z.string().describe('Issue ID'),
       title: z.string().min(1).max(500).optional().describe('New title'),
       statusId: z.enum(['todo', 'working', 'review', 'done']).optional().describe('New status'),
+      tags: z.array(z.string().max(50)).max(10).nullable().optional().describe('Tags for grouping issues. Pass null to clear tags.'),
     }),
-  }, async ({ projectId, issueId, title, statusId }) => {
+  }, async ({ projectId, issueId, title, statusId, tags }) => {
     const project = await findProject(projectId)
     if (!project) return errorResult('Project not found')
 
@@ -438,6 +466,7 @@ export function createMcpServer(): McpServer {
       ...(statusId !== undefined && { statusId }),
       ...(statusId !== undefined && statusId !== existing.statusId && { statusUpdatedAt: new Date() }),
       ...(shouldExecute && { sessionStatus: 'pending' as const }),
+      ...(tags !== undefined && { tag: serializeTags(tags) }),
     }
 
     if (Object.keys(updates).length === 0) {
@@ -534,12 +563,20 @@ export function createMcpServer(): McpServer {
 
   server.registerTool('execute-issue', {
     title: 'Execute Issue',
-    description: 'Start AI engine execution on an issue. Automatically moves review issues to working.',
+    description: [
+      'Start AI engine execution on an issue. Automatically moves review issues to working.',
+      '',
+      'Important reminders:',
+      '- Ensure the project has correct global configuration (system prompt, env vars, working directory) before executing to prevent task failures.',
+      '- Check list-processes to monitor current workload before starting new executions.',
+      '- After task completion, the issue should be moved to "review" (not "done") to await human confirmation.',
+      '- For git repositories, commit changes organized by feature/function before moving to review.',
+    ].join('\n'),
     inputSchema: z.object({
       projectId: z.string().describe('Project ID or alias'),
       issueId: z.string().describe('Issue ID'),
       prompt: z.string().min(1).max(32768).describe('Prompt / instructions for the AI agent'),
-      engineType: z.enum(['claude-code', 'codex', 'acp', 'echo']).describe('AI engine type'),
+      engineType: z.enum(['claude-code', 'codex']).describe('AI engine type'),
       model: z.string().optional().describe('Model ID'),
     }),
   }, async ({ projectId, issueId, prompt, engineType, model }) => {
@@ -589,11 +626,18 @@ export function createMcpServer(): McpServer {
 
   server.registerTool('follow-up-issue', {
     title: 'Follow Up Issue',
-    description: 'Send a follow-up message to an active AI session on an issue.',
+    description: [
+      'Send a follow-up message to an active AI session on an issue.',
+      '',
+      'Best practices:',
+      '- Use this to send detailed requirements after creating an issue with a short title.',
+      '- Include specific context: acceptance criteria, constraints, file paths, code examples.',
+      '- For git repos, remind the agent to commit changes by feature and move issue to "review" when done.',
+    ].join('\n'),
     inputSchema: z.object({
       projectId: z.string().describe('Project ID or alias'),
       issueId: z.string().describe('Issue ID'),
-      prompt: z.string().min(1).max(32768).describe('Follow-up message'),
+      prompt: z.string().min(1).max(32768).describe('Follow-up message with detailed requirements'),
       model: z.string().optional().describe('Model ID (cannot change during active session)'),
     }),
   }, async ({ projectId, issueId, prompt, model }) => {
@@ -705,20 +749,56 @@ export function createMcpServer(): McpServer {
     return textResult({ engines, models })
   })
 
+  // ==================== Process Monitoring ====================
+
+  server.registerTool('list-processes', {
+    title: 'List Active Processes',
+    description: 'List all active AI engine processes across all projects. Returns process count, state, engine type, model, and associated issue/project info. Use this to monitor system workload before starting new tasks.',
+    inputSchema: z.object({}),
+  }, async () => {
+    const processes = await buildProcessInfoList()
+    const summary = {
+      totalActive: processes.length,
+      byState: {} as Record<string, number>,
+      byEngine: {} as Record<string, number>,
+      byProject: {} as Record<string, { projectName: string, count: number }>,
+    }
+
+    for (const p of processes) {
+      summary.byState[p.processState] = (summary.byState[p.processState] ?? 0) + 1
+      summary.byEngine[p.engineType] = (summary.byEngine[p.engineType] ?? 0) + 1
+      if (!summary.byProject[p.projectId]) {
+        summary.byProject[p.projectId] = { projectName: p.projectName, count: 0 }
+      }
+      summary.byProject[p.projectId].count++
+    }
+
+    return textResult({ summary, processes })
+  })
+
   // ==================== Issue Logs ====================
 
   server.registerTool('get-issue-logs', {
     title: 'Get Issue Logs',
-    description: 'Get execution logs for an issue. By default returns only user and assistant messages (no tool output noise). Use entryTypes to include other types.',
+    description: [
+      'Get execution logs for an issue. By default returns only user and assistant messages (no tool output noise).',
+      '',
+      'Features:',
+      '- Set lastTurn=true to get only the last turn\'s conversation (useful for checking the latest agent response).',
+      '- Returns sessionStatus so you know the current session state (running/completed/failed/cancelled).',
+      '- Analyze the last assistant message content to determine if the agent is waiting for user input (e.g. asking questions, requesting confirmation).',
+      '- Based on the content and sessionStatus, decide next action: send a follow-up, restart, or move to review.',
+    ].join('\n'),
     inputSchema: z.object({
       projectId: z.string().describe('Project ID or alias'),
       issueId: z.string().describe('Issue ID'),
       limit: z.number().min(1).max(200).optional().describe('Max entries to return. Default: 50'),
+      lastTurn: z.boolean().optional().describe('If true, return only the last turn\'s user and assistant messages.'),
       entryTypes: z.array(z.enum(['user-message', 'assistant-message', 'tool-use', 'system-message', 'thinking']))
         .optional()
         .describe('Entry types to include. Default: ["user-message", "assistant-message"]'),
     }),
-  }, async ({ projectId, issueId, limit, entryTypes }: { projectId: string, issueId: string, limit?: number, entryTypes?: string[] }) => {
+  }, async ({ projectId, issueId, limit, lastTurn, entryTypes }: { projectId: string, issueId: string, limit?: number, lastTurn?: boolean, entryTypes?: string[] }) => {
     const project = await findProject(projectId)
     if (!project) return errorResult('Project not found')
 
@@ -734,18 +814,34 @@ export function createMcpServer(): McpServer {
       )
     if (!issue) return errorResult('Issue not found')
 
-    const { entries } = getLogsFromDb(issueId, {
-      limit: limit ?? 50,
+    // When lastTurn is requested, ignore caller limit to return the full turn
+    const queryOpts: Parameters<typeof getLogsFromDb>[1] = {
+      limit: lastTurn ? 200 : (limit ?? 50),
       entryTypes: entryTypes ?? ['user-message', 'assistant-message'],
-    })
+    }
 
-    return textResult(entries.map(e => ({
-      id: e.messageId,
-      entryType: e.entryType,
-      content: e.content,
-      timestamp: e.timestamp,
-      turnIndex: e.turnIndex,
-    })))
+    // Filter to last turn if requested
+    if (lastTurn) {
+      const nextTurn = getNextTurnIndex(issueId)
+      if (nextTurn === 0) {
+        return textResult({ sessionStatus: issue.sessionStatus ?? null, entries: [] })
+      }
+      queryOpts.turnIndex = nextTurn - 1
+      queryOpts.turnIndexEnd = nextTurn - 1
+    }
+
+    const { entries } = getLogsFromDb(issueId, queryOpts)
+
+    return textResult({
+      sessionStatus: issue.sessionStatus ?? null,
+      entries: entries.map(e => ({
+        id: e.messageId,
+        entryType: e.entryType,
+        content: e.content,
+        timestamp: e.timestamp,
+        turnIndex: e.turnIndex,
+      })),
+    })
   })
 
   return server

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -107,7 +107,7 @@ export function serializeIssue(row: IssueRow) {
 }
 
 /** Parse JSON-encoded tags from DB text column into string array. */
-function parseTags(raw: string | null | undefined): string[] | null {
+export function parseTags(raw: string | null | undefined): string[] | null {
   if (!raw) return null
   let candidates: string[]
   try {

--- a/apps/api/src/routes/issues/duplicate.ts
+++ b/apps/api/src/routes/issues/duplicate.ts
@@ -1,11 +1,11 @@
-import { and, asc, desc, eq, inArray, max } from 'drizzle-orm'
+import { and, asc, desc, eq, max } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { generateKeyBetween } from 'jittered-fractional-indexing'
 import { ulid } from 'ulid'
 import { cacheDelByPrefix } from '@/cache'
 import { db } from '@/db'
 import { findProject } from '@/db/helpers'
-import { issues as issuesTable, issueLogs as logsTable, issuesLogsToolsCall as toolsTable } from '@/db/schema'
+import { issues as issuesTable, issueLogs as logsTable } from '@/db/schema'
 import { getProjectOwnedIssue, serializeIssue } from './_shared'
 
 const duplicate = new Hono()
@@ -66,19 +66,27 @@ duplicate.post('/:id/duplicate', async (c) => {
 
     if (!created) return []
 
-    // Copy issue logs
+    // Copy only user and assistant message logs (no tool calls)
     const sourceLogs = await tx
       .select()
       .from(logsTable)
-      .where(eq(logsTable.issueId, issueId))
+      .where(
+        and(
+          eq(logsTable.issueId, issueId),
+          eq(logsTable.visible, 1),
+        ),
+      )
       .orderBy(asc(logsTable.id))
 
-    if (sourceLogs.length > 0) {
-      // Map old log ID -> new log ID
+    const messageLogs = sourceLogs.filter(
+      log => log.entryType === 'user-message' || log.entryType === 'assistant-message',
+    )
+
+    if (messageLogs.length > 0) {
       const logIdMap = new Map<string, string>()
       const now = new Date()
 
-      for (const log of sourceLogs) {
+      for (const log of messageLogs) {
         const newLogId = ulid()
         logIdMap.set(log.id, newLogId)
 
@@ -92,39 +100,11 @@ duplicate.post('/:id/duplicate', async (c) => {
           metadata: log.metadata,
           replyToMessageId: log.replyToMessageId ? (logIdMap.get(log.replyToMessageId) ?? log.replyToMessageId) : null,
           timestamp: log.timestamp,
-          toolCallRefId: log.toolCallRefId,
+          toolCallRefId: null,
           visible: log.visible,
           createdAt: now,
           updatedAt: now,
         })
-      }
-
-      // Copy tool calls in batches
-      const oldLogIds = sourceLogs.map(l => l.id)
-      for (let i = 0; i < oldLogIds.length; i += 500) {
-        const chunk = oldLogIds.slice(i, i + 500)
-        const toolRows = await tx
-          .select()
-          .from(toolsTable)
-          .where(inArray(toolsTable.logId, chunk))
-
-        for (const tool of toolRows) {
-          const newLogId = logIdMap.get(tool.logId)
-          if (!newLogId) continue
-
-          await tx.insert(toolsTable).values({
-            id: ulid(),
-            logId: newLogId,
-            issueId: created.id,
-            toolName: tool.toolName,
-            toolCallId: tool.toolCallId,
-            kind: tool.kind,
-            isResult: tool.isResult,
-            raw: tool.raw,
-            createdAt: now,
-            updatedAt: now,
-          })
-        }
       }
     }
 

--- a/apps/api/src/routes/issues/export.ts
+++ b/apps/api/src/routes/issues/export.ts
@@ -68,41 +68,8 @@ function getAllLogs(issueId: string): NormalizedLogEntry[] {
     .filter(isVisible)
 }
 
-function logsToText(logs: NormalizedLogEntry[], issueTitle: string): string {
-  const lines: string[] = [`# ${issueTitle}`, '']
-
-  for (const log of logs) {
-    if (log.entryType === 'user-message') {
-      lines.push(`## User`)
-      lines.push('')
-      lines.push(log.content)
-      lines.push('')
-    } else if (log.entryType === 'assistant-message') {
-      lines.push(`## Assistant`)
-      lines.push('')
-      lines.push(log.content)
-      lines.push('')
-    } else if (log.entryType === 'tool-use' && log.toolAction) {
-      const action = log.toolAction
-      if (action.kind === 'command-run') {
-        lines.push(`> Command: ${action.command}`)
-        if (action.result) lines.push(`> Result: ${action.result}`)
-        lines.push('')
-      } else if (action.kind === 'file-read') {
-        lines.push(`> Read: ${action.path}`)
-        lines.push('')
-      } else if (action.kind === 'file-edit') {
-        lines.push(`> Edit: ${action.path}`)
-        lines.push('')
-      }
-    }
-  }
-
-  return lines.join('\n')
-}
-
 const exportQuerySchema = z.object({
-  format: z.enum(['json', 'txt']).default('json'),
+  format: z.enum(['json']).default('json'),
 })
 
 // GET /api/projects/:projectId/issues/:id/export — Export issue logs
@@ -119,21 +86,9 @@ exportRoute.get('/:id/export', zValidator('query', exportQuerySchema), async (c)
     return c.json({ success: false, error: 'Issue not found' }, 404)
   }
 
-  const { format } = c.req.valid('query')
   const logs = getAllLogs(issueId)
   const filename = `issue-${issue.issueNumber}-${issue.id}`
 
-  if (format === 'txt') {
-    const text = logsToText(logs, issue.title)
-    return new Response(text, {
-      headers: {
-        'Content-Type': 'text/plain; charset=utf-8',
-        'Content-Disposition': `attachment; filename="${filename}.txt"`,
-      },
-    })
-  }
-
-  // Default: JSON
   const json = JSON.stringify({ issue: { id: issue.id, title: issue.title, issueNumber: issue.issueNumber }, logs }, null, 2)
   return new Response(json, {
     headers: {

--- a/apps/api/src/routes/processes.ts
+++ b/apps/api/src/routes/processes.ts
@@ -7,7 +7,7 @@ import { getPidFromManaged } from '@/engines/issue/utils/pid'
 import { logger } from '@/logger'
 import type { ProcessInfo } from '@bkd/shared'
 
-async function buildProcessInfoList(): Promise<ProcessInfo[]> {
+export async function buildProcessInfoList(): Promise<ProcessInfo[]> {
   const activeProcesses = issueEngine.getActiveProcesses()
   const issueIds = activeProcesses.map(p => p.issueId)
   if (issueIds.length === 0) return []

--- a/apps/api/test/api-mcp.test.ts
+++ b/apps/api/test/api-mcp.test.ts
@@ -163,7 +163,6 @@ describe('MCP /api/mcp', () => {
       projectId,
       title: 'MCP test task',
       statusId: 'todo',
-      engineType: 'echo',
     })
     const issue = parseToolResult(createResult)
     expect(issue.title).toBe('MCP test task')

--- a/apps/frontend/src/components/AppSettingsDialog.tsx
+++ b/apps/frontend/src/components/AppSettingsDialog.tsx
@@ -696,6 +696,7 @@ function McpSection({ open }: { open: boolean }) {
     {
       mcpServers: {
         bkd: {
+          type: 'http',
           url: `${serverUrl}/api/mcp`,
           ...(apiKey ? { headers: { Authorization: `Bearer ${apiKey}` } } : {}),
         },

--- a/apps/frontend/src/components/issue-detail/IssueContextMenu.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueContextMenu.tsx
@@ -25,9 +25,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { useDeleteIssue, useDuplicateIssue, useUpdateIssue } from '@/hooks/use-kanban'
@@ -130,18 +127,15 @@ export function IssueContextMenu({
     duplicateIssue.mutate(issue.id)
   }, [duplicateIssue, issue.id])
 
-  const handleExport = useCallback(
-    (format: 'json' | 'txt') => {
-      const url = kanbanApi.exportIssueUrl(projectId, issue.id, format)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = ''
-      document.body.appendChild(a)
-      a.click()
-      document.body.removeChild(a)
-    },
-    [projectId, issue.id],
-  )
+  const handleExport = useCallback(() => {
+    const url = kanbanApi.exportIssueUrl(projectId, issue.id)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = ''
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+  }, [projectId, issue.id])
 
   const handleDelete = useCallback(() => {
     deleteIssue.mutate(issue.id)
@@ -178,20 +172,10 @@ export function IssueContextMenu({
             <Copy className="size-4" />
             {t('contextMenu.copy')}
           </DropdownMenuItem>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              <Download className="size-4" />
-              {t('contextMenu.download')}
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              <DropdownMenuItem onSelect={() => handleExport('json')}>
-                {t('contextMenu.exportJson')}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => handleExport('txt')}>
-                {t('contextMenu.exportTxt')}
-              </DropdownMenuItem>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
+          <DropdownMenuItem onSelect={handleExport}>
+            <Download className="size-4" />
+            {t('contextMenu.download')}
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem variant="destructive" onSelect={() => setDeleteOpen(true)}>
             <Trash2 className="size-4" />

--- a/apps/frontend/src/components/issue-detail/IssueListPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueListPanel.tsx
@@ -9,7 +9,7 @@ import {
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { IssueContextMenu, RenameDialog } from '@/components/issue-detail/IssueContextMenu'
+import { IssueContextMenu } from '@/components/issue-detail/IssueContextMenu'
 import { ProjectSettingsDialog } from '@/components/ProjectSettingsDialog'
 import { Button } from '@/components/ui/button'
 import { useIssues, useProject } from '@/hooks/use-kanban'
@@ -266,68 +266,54 @@ const IssueRow = memo(({
   isActive: boolean
   onNavigate: (issueId: string) => void
 }) => {
-  const [renameOpen, setRenameOpen] = useState(false)
-
   const handleClick = useCallback(() => {
-    if (isActive) {
-      setRenameOpen(true)
-    } else {
+    if (!isActive) {
       onNavigate(issue.id)
     }
   }, [isActive, issue.id, onNavigate])
 
   return (
-    <>
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={handleClick}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            handleClick()
-          }
-        }}
-        className={`group w-full flex items-center gap-1 px-1.5 py-2.5 md:py-1.5 text-left border-b border-border/20 transition-all duration-150 cursor-pointer ${
-          isActive ? 'bg-primary/[0.06]' : 'hover:bg-accent/50'
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleClick()
+        }
+      }}
+      className={`group w-full flex items-center gap-1 px-1.5 py-2.5 md:py-1.5 text-left border-b border-border/20 transition-all duration-150 ${
+        isActive ? 'bg-primary/[0.06] cursor-default' : 'hover:bg-accent/50 cursor-pointer'
+      }`}
+    >
+      <span className="w-3.5 shrink-0" />
+      <span
+        className={`text-[11px] font-mono shrink-0 tabular-nums ${
+          isActive ? 'text-primary font-medium' : 'text-muted-foreground/70'
         }`}
       >
-        <span className="w-3.5 shrink-0" />
-        <span
-          className={`text-[11px] font-mono shrink-0 tabular-nums ${
-            isActive ? 'text-primary font-medium' : 'text-muted-foreground/70'
-          }`}
-        >
-          #
-          {issue.issueNumber}
-        </span>
-        <span
-          title={issue.title}
-          className={`text-[13px] truncate ${
-            isActive ? 'text-foreground font-medium' : 'text-foreground/90'
-          }`}
-        >
-          {issue.title}
-        </span>
-        <div className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity shrink-0" onClick={e => e.stopPropagation()} onPointerDown={e => e.stopPropagation()}>
-          <IssueContextMenu issue={issue} projectId={projectId}>
-            <button
-              type="button"
-              className="inline-flex items-center justify-center rounded-md p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <MoreHorizontal className="size-3.5" />
-            </button>
-          </IssueContextMenu>
-        </div>
+        #
+        {issue.issueNumber}
+      </span>
+      <span
+        title={issue.title}
+        className={`text-[13px] truncate ${
+          isActive ? 'text-foreground font-medium' : 'text-foreground/90'
+        }`}
+      >
+        {issue.title}
+      </span>
+      <div className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity shrink-0" onClick={e => e.stopPropagation()} onPointerDown={e => e.stopPropagation()}>
+        <IssueContextMenu issue={issue} projectId={projectId}>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-md p-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+          >
+            <MoreHorizontal className="size-3.5" />
+          </button>
+        </IssueContextMenu>
       </div>
-
-      {/* Rename dialog triggered by clicking active issue */}
-      <RenameDialog
-        open={renameOpen}
-        onOpenChange={setRenameOpen}
-        issue={issue}
-        projectId={projectId}
-      />
-    </>
+    </div>
   )
 })

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -437,8 +437,6 @@
     "rename": "Rename",
     "copy": "Copy",
     "download": "Download",
-    "exportJson": "Export chat (.json)",
-    "exportTxt": "TXT document (.txt)",
     "delete": "Delete",
     "deleteConfirm": "Are you sure you want to delete this issue?",
     "copySuccess": "Issue duplicated",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -437,8 +437,6 @@
     "rename": "重命名",
     "copy": "复制",
     "download": "下载",
-    "exportJson": "导出聊天记录 (.json)",
-    "exportTxt": "TXT 文档 (.txt)",
     "delete": "删除",
     "deleteConfirm": "确定要删除此任务吗？",
     "copySuccess": "任务已复制",

--- a/apps/frontend/src/lib/kanban-api.ts
+++ b/apps/frontend/src/lib/kanban-api.ts
@@ -175,8 +175,8 @@ export const kanbanApi = {
     del<{ id: string }>(`/api/projects/${projectId}/issues/${issueId}`),
   duplicateIssue: (projectId: string, issueId: string) =>
     post<Issue>(`/api/projects/${projectId}/issues/${issueId}/duplicate`, {}),
-  exportIssueUrl: (projectId: string, issueId: string, format: 'json' | 'txt') =>
-    `/api/projects/${projectId}/issues/${issueId}/export?format=${format}`,
+  exportIssueUrl: (projectId: string, issueId: string) =>
+    `/api/projects/${projectId}/issues/${issueId}/export?format=json`,
 
   // Issue session operations (merged from sessions)
   executeIssue: (projectId: string, issueId: string, data: ExecuteIssueRequest) =>


### PR DESCRIPTION
## Summary

- Add `list-processes` MCP tool for global process monitoring across all projects (with summary stats by state/engine/project)
- Add `useWorktree` parameter to `create-issue` for isolated git worktree execution
- Add `lastTurn` parameter to `get-issue-logs` for retrieving only the last turn's conversation
- Include `sessionStatus` in `get-issue-logs` response for AI-driven session state analysis
- Enrich tool descriptions with best practice guidance:
  - Short titles + follow-up for detailed requirements
  - Worktree recommendations for complex tasks
  - Review-not-done completion workflow
  - Global config compliance reminders
  - Process workload monitoring before execution
- Narrow engine type enum to `claude-code` and `codex` in MCP schemas
- Export `buildProcessInfoList` from processes route for MCP reuse

## Test plan

- [ ] Verify `list-processes` returns correct summary and process details
- [ ] Verify `create-issue` with `useWorktree=true` persists the flag correctly
- [ ] Verify `get-issue-logs` with `lastTurn=true` returns only the last turn entries
- [ ] Verify `get-issue-logs` with `lastTurn=true` on an issue with no logs returns empty entries
- [ ] Verify engine type validation rejects `acp` and `echo` in MCP create/execute
- [ ] Verify tool descriptions render correctly in MCP client tool listings