### PR TITLE
feat: add keepAlive toggle to prevent idle timeout termination

### DIFF
--- a/apps/api/drizzle/0013_tough_squadron_sinister.sql
+++ b/apps/api/drizzle/0013_tough_squadron_sinister.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `issues` ADD `keep_alive` integer DEFAULT 0 NOT NULL;

--- a/apps/api/drizzle/meta/0013_snapshot.json
+++ b/apps/api/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1118 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a0c2899e-265c-4526-96af-36b06e30cf08",
+  "prevId": "2b64e62e-cff0-4803-b062-3a54e30791a9",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "attachments_issue_id_idx": {
+          "name": "attachments_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "attachments_log_id_idx": {
+          "name": "attachments_log_id_idx",
+          "columns": [
+            "log_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "attachments_issue_id_issues_id_fk": {
+          "name": "attachments_issue_id_issues_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attachments_log_id_issues_logs_id_fk": {
+          "name": "attachments_log_id_issues_logs_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "issues_logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "issues_logs": {
+      "name": "issues_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_index": {
+          "name": "turn_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entry_index": {
+          "name": "entry_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_message_id": {
+          "name": "reply_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_ref_id": {
+          "name": "tool_call_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_logs_issue_id_idx": {
+          "name": "issues_logs_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_issue_id_turn_entry_idx": {
+          "name": "issues_logs_issue_id_turn_entry_idx",
+          "columns": [
+            "issue_id",
+            "turn_index",
+            "entry_index"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_issue_id_visible_type_idx": {
+          "name": "issues_logs_issue_id_visible_type_idx",
+          "columns": [
+            "issue_id",
+            "visible",
+            "entry_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "issues_logs_issue_id_issues_id_fk": {
+          "name": "issues_logs_issue_id_issues_id_fk",
+          "tableFrom": "issues_logs",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "issues": {
+      "name": "issues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'a0'"
+        },
+        "parent_issue_id": {
+          "name": "parent_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_worktree": {
+          "name": "use_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "keep_alive": {
+          "name": "keep_alive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "engine_type": {
+          "name": "engine_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_status": {
+          "name": "session_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_session_id": {
+          "name": "external_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_input_tokens": {
+          "name": "total_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_output_tokens": {
+          "name": "total_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_project_id_idx": {
+          "name": "issues_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "issues_status_id_idx": {
+          "name": "issues_status_id_idx",
+          "columns": [
+            "status_id"
+          ],
+          "isUnique": false
+        },
+        "issues_parent_issue_id_idx": {
+          "name": "issues_parent_issue_id_idx",
+          "columns": [
+            "parent_issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_project_id_status_updated_at_idx": {
+          "name": "issues_project_id_status_updated_at_idx",
+          "columns": [
+            "project_id",
+            "status_updated_at"
+          ],
+          "isUnique": false
+        },
+        "issues_project_id_issue_number_uniq": {
+          "name": "issues_project_id_issue_number_uniq",
+          "columns": [
+            "project_id",
+            "issue_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_parent_issue_id_issues_id_fk": {
+          "name": "issues_parent_issue_id_issues_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "parent_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "issues_status_id_check": {
+          "name": "issues_status_id_check",
+          "value": "\"issues\".\"status_id\" IN ('todo','working','review','done')"
+        }
+      }
+    },
+    "issues_logs_tools_call": {
+      "name": "issues_logs_tools_call",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_result": {
+          "name": "is_result",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "issues_logs_tools_call_log_id_idx": {
+          "name": "issues_logs_tools_call_log_id_idx",
+          "columns": [
+            "log_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_issue_id_idx": {
+          "name": "issues_logs_tools_call_issue_id_idx",
+          "columns": [
+            "issue_id"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_kind_idx": {
+          "name": "issues_logs_tools_call_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_tool_name_idx": {
+          "name": "issues_logs_tools_call_tool_name_idx",
+          "columns": [
+            "tool_name"
+          ],
+          "isUnique": false
+        },
+        "issues_logs_tools_call_issue_id_kind_idx": {
+          "name": "issues_logs_tools_call_issue_id_kind_idx",
+          "columns": [
+            "issue_id",
+            "kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "issues_logs_tools_call_log_id_issues_logs_id_fk": {
+          "name": "issues_logs_tools_call_log_id_issues_logs_id_fk",
+          "tableFrom": "issues_logs_tools_call",
+          "tableTo": "issues_logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issues_logs_tools_call_issue_id_issues_id_fk": {
+          "name": "issues_logs_tools_call_issue_id_issues_id_fk",
+          "tableFrom": "issues_logs_tools_call",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "directory": {
+          "name": "directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env_vars": {
+          "name": "env_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'a0'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "projects_alias_unique": {
+          "name": "projects_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_webhook_id_idx": {
+          "name": "webhook_deliveries_webhook_id_idx",
+          "columns": [
+            "webhook_id"
+          ],
+          "isUnique": false
+        },
+        "webhook_deliveries_created_at_idx": {
+          "name": "webhook_deliveries_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "webhook_deliveries_dedup_idx": {
+          "name": "webhook_deliveries_dedup_idx",
+          "columns": [
+            "webhook_id",
+            "dedup_key",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1773792000000,
       "tag": "0012_add_is_pinned",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1774098590911,
+      "tag": "0013_tough_squadron_sinister",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -57,6 +57,7 @@ export const issues = sqliteTable(
     parentIssueId: text('parent_issue_id').references((): any => issues.id),
     useWorktree: integer('use_worktree', { mode: 'boolean' }).notNull().default(false),
     isPinned: integer('is_pinned', { mode: 'boolean' }).notNull().default(false),
+    keepAlive: integer('keep_alive', { mode: 'boolean' }).notNull().default(false),
     // Session fields (null = no engine session started)
     engineType: text('engine_type'),
     sessionStatus: text('session_status'),

--- a/apps/api/src/engines/issue/engine.ts
+++ b/apps/api/src/engines/issue/engine.ts
@@ -202,6 +202,12 @@ export class IssueEngine {
     return getActiveProcessesList(this.ctx)
   }
 
+  /** Sync keepAlive flag to any active in-memory process for this issue */
+  updateKeepAlive(issueId: string, keepAlive: boolean): void {
+    const active = this.ctx.pm.getFirstActiveInGroup(issueId)?.meta
+    if (active) active.keepAlive = keepAlive
+  }
+
   async cancelAll(): Promise<void> {
     return cancelAll(this.ctx)
   }

--- a/apps/api/src/engines/issue/gc.ts
+++ b/apps/api/src/engines/issue/gc.ts
@@ -118,17 +118,21 @@ export function gcSweep(ctx: EngineContext): void {
         !managed.turnInFlight &&
         now - managed.lastIdleAt.getTime() > IDLE_TIMEOUT_MS
       ) {
-        logger.info(
-          {
-            issueId: managed.issueId,
-            executionId: managed.executionId,
-            idleMinutes: Math.round((now - managed.lastIdleAt.getTime()) / 60000),
-          },
-          'idle_timeout_terminate',
-        )
-        terminateAndSettle(ctx, entry.id, managed, 'completed')
-        cleaned++
-        continue
+        // Skip idle timeout for issues with keepAlive enabled
+        if (!managed.keepAlive) {
+          logger.info(
+            {
+              issueId: managed.issueId,
+              executionId: managed.executionId,
+              idleMinutes: Math.round((now - managed.lastIdleAt.getTime()) / 60000),
+            },
+            'idle_timeout_terminate',
+          )
+          terminateAndSettle(ctx, entry.id, managed, 'completed')
+          cleaned++
+          continue
+        }
+        // keepAlive: skip termination but fall through to stall detection
       }
 
       // --- Check 2: Stream stall detection (turn in-flight but no output) ---

--- a/apps/api/src/engines/issue/lifecycle/spawn.ts
+++ b/apps/api/src/engines/issue/lifecycle/spawn.ts
@@ -231,6 +231,7 @@ export async function spawnRetry(
     worktreePath ? baseDir : undefined,
     workingDir,
     spawned.externalSessionId ?? issue.sessionFields.externalSessionId ?? undefined,
+    issue.keepAlive,
   )
   monitorCompletion(ctx, executionId, issueId, engineType, true)
   logger.debug({ issueId, executionId, engineType, turnIndex }, 'issue_retry_spawned')
@@ -384,6 +385,7 @@ export async function spawnFollowUpProcess(
     worktreePath ? baseDir : undefined,
     workingDir,
     spawned.externalSessionId ?? issue.sessionFields.externalSessionId ?? undefined,
+    issue.keepAlive,
   )
   // User message already persisted above (before spawn)
   monitorCompletion(ctx, executionId, issueId, engineType, false)

--- a/apps/api/src/engines/issue/orchestration/execute.ts
+++ b/apps/api/src/engines/issue/orchestration/execute.ts
@@ -158,6 +158,7 @@ export async function executeIssue(
       worktreePath ? baseDir : undefined,
       workingDir,
       finalExternalSessionId,
+      issue.keepAlive,
     )
     emitDiagnosticLog(
       issueId,

--- a/apps/api/src/engines/issue/orchestration/restart.ts
+++ b/apps/api/src/engines/issue/orchestration/restart.ts
@@ -136,6 +136,7 @@ export async function restartIssue(
       worktreePath ? baseDir : undefined,
       workingDir,
       spawned.externalSessionId ?? issue.sessionFields.externalSessionId ?? undefined,
+      issue.keepAlive,
     )
     monitorCompletion(ctx, executionId, issueId, engineType, false)
 

--- a/apps/api/src/engines/issue/process/register.ts
+++ b/apps/api/src/engines/issue/process/register.ts
@@ -32,6 +32,7 @@ export function register(
   worktreeBaseDir?: string,
   spawnCwd?: string,
   externalSessionId?: string,
+  keepAlive?: boolean,
 ): ManagedProcess {
   const managed: ManagedProcess = {
     executionId,
@@ -47,6 +48,7 @@ export function register(
     logicalFailure: false,
     turnSettled: false,
     metaTurn,
+    keepAlive: keepAlive ?? false,
     lastActivityAt: new Date(),
     slashCommands: [],
     agents: [],

--- a/apps/api/src/engines/issue/types.ts
+++ b/apps/api/src/engines/issue/types.ts
@@ -61,6 +61,8 @@ export interface ManagedProcess {
    *  process and abort instead of hard-killing a legitimate turn.
    */
   cancelEscalationId?: string
+  /** Prevent idle timeout from terminating this process (mirrors issue.keepAlive) */
+  keepAlive: boolean
   /** Git repo directory that owns this worktree (needed for `git worktree remove`) */
   worktreeBaseDir?: string
   worktreePath?: string

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -62,6 +62,7 @@ function serializeIssue(row: typeof issuesTable.$inferSelect) {
     engineType: row.engineType ?? null,
     sessionStatus: row.sessionStatus ?? null,
     model: row.model ?? null,
+    keepAlive: row.keepAlive,
     statusUpdatedAt: toISO(row.statusUpdatedAt),
     createdAt: toISO(row.createdAt),
     updatedAt: toISO(row.updatedAt),
@@ -155,10 +156,11 @@ async function insertIssueInTransaction(
     model: string | null
     sessionStatus: string | null
     useWorktree?: boolean
+    keepAlive?: boolean
     tags?: string[]
   },
 ) {
-  const { statusId, title, engineType, model, sessionStatus, useWorktree, tags } = opts
+  const { statusId, title, engineType, model, sessionStatus, useWorktree, keepAlive, tags } = opts
 
   const [newIssue] = await db.transaction(async (tx) => {
     const [maxNumRow] = await tx
@@ -194,6 +196,7 @@ async function insertIssueInTransaction(
         sessionStatus,
         prompt: title,
         useWorktree: useWorktree ?? false,
+        keepAlive: keepAlive ?? false,
         tag: serializeTags(tags),
       })
       .returning()
@@ -376,9 +379,10 @@ export function createMcpServer(): McpServer {
       engineType: z.enum(['claude-code', 'codex']).optional().describe('AI engine type. Defaults to server setting.'),
       model: z.string().optional().describe('Model ID. Defaults to engine default.'),
       useWorktree: z.boolean().optional().describe('If true, execute in an isolated git worktree. Recommended for complex multi-file changes.'),
+      keepAlive: z.boolean().optional().describe('If true, prevent idle timeout from terminating the process. Useful for long-running sessions.'),
       tags: z.array(z.string().max(50)).max(10).optional().describe('Tags for grouping issues (max 10 tags, each max 50 chars).'),
     }),
-  }, async ({ projectId, title, statusId, engineType, model, useWorktree, tags }) => {
+  }, async ({ projectId, title, statusId, engineType, model, useWorktree, keepAlive, tags }) => {
     const project = await findProject(projectId)
     if (!project) return errorResult('Project not found')
 
@@ -393,6 +397,7 @@ export function createMcpServer(): McpServer {
       model: resolved.model,
       sessionStatus: shouldExecute ? 'pending' : null,
       useWorktree,
+      keepAlive,
       tags,
     })
 
@@ -443,9 +448,10 @@ export function createMcpServer(): McpServer {
       issueId: z.string().describe('Issue ID'),
       title: z.string().min(1).max(500).optional().describe('New title'),
       statusId: z.enum(['todo', 'working', 'review', 'done']).optional().describe('New status'),
+      keepAlive: z.boolean().optional().describe('If true, prevent idle timeout from terminating the process.'),
       tags: z.array(z.string().max(50)).max(10).nullable().optional().describe('Tags for grouping issues. Pass null to clear tags.'),
     }),
-  }, async ({ projectId, issueId, title, statusId, tags }) => {
+  }, async ({ projectId, issueId, title, statusId, keepAlive, tags }) => {
     const project = await findProject(projectId)
     if (!project) return errorResult('Project not found')
 
@@ -473,7 +479,13 @@ export function createMcpServer(): McpServer {
       ...(statusId !== undefined && { statusId }),
       ...(statusId !== undefined && statusId !== existing.statusId && { statusUpdatedAt: new Date() }),
       ...(shouldExecute && { sessionStatus: 'pending' as const }),
+      ...(keepAlive !== undefined && { keepAlive }),
       ...(tags !== undefined && { tag: serializeTags(tags) }),
+    }
+
+    // Sync keepAlive to in-memory process so GC picks up the change immediately
+    if (keepAlive !== undefined) {
+      issueEngine.updateKeepAlive(issueId, keepAlive)
     }
 
     if (Object.keys(updates).length === 0) {

--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -25,6 +25,7 @@ export const createIssueSchema = z.object({
   tags: z.array(z.string().max(50)).max(10).optional(),
   statusId: z.enum(STATUS_IDS),
   useWorktree: z.boolean().optional(),
+  keepAlive: z.boolean().optional(),
   engineType: z.string().refine(
     val => ['claude-code', 'codex', 'acp', 'echo'].includes(val) || isValidAcpEngineType(val),
     { message: 'Invalid engine type' },
@@ -54,6 +55,7 @@ export const updateIssueSchema = z.object({
   statusId: z.enum(STATUS_IDS).optional(),
   sortOrder: z.string().min(1).max(50).regex(fractionalKeyRegex).optional(),
   isPinned: z.boolean().optional(),
+  keepAlive: z.boolean().optional(),
 })
 
 export const executeIssueSchema = z.object({
@@ -94,6 +96,7 @@ export function serializeIssue(row: IssueRow) {
     sortOrder: row.sortOrder,
     useWorktree: row.useWorktree,
     isPinned: row.isPinned,
+    keepAlive: row.keepAlive,
     // Session fields
     engineType: row.engineType ?? null,
     sessionStatus: row.sessionStatus ?? null,

--- a/apps/api/src/routes/issues/create.ts
+++ b/apps/api/src/routes/issues/create.ts
@@ -99,6 +99,7 @@ create.post(
             tag: serializeTags(body.tags),
             sortOrder,
             useWorktree: body.useWorktree ?? false,
+            keepAlive: body.keepAlive ?? false,
             engineType: resolvedEngine,
             model: resolvedModel,
             sessionStatus: shouldExecute ? 'pending' : null,

--- a/apps/api/src/routes/issues/update.ts
+++ b/apps/api/src/routes/issues/update.ts
@@ -227,6 +227,11 @@ update.patch(
     }
     if (body.sortOrder !== undefined) updates.sortOrder = body.sortOrder
     if (body.isPinned !== undefined) updates.isPinned = body.isPinned
+    if (body.keepAlive !== undefined) {
+      updates.keepAlive = body.keepAlive
+      // Sync to in-memory process so GC picks up the change immediately
+      issueEngine.updateKeepAlive(issueId, body.keepAlive)
+    }
 
     if (Object.keys(updates).length === 0) {
       return c.json({ success: true, data: serializeIssue(existing) })

--- a/apps/api/test/gc-stall-detection.test.ts
+++ b/apps/api/test/gc-stall-detection.test.ts
@@ -37,6 +37,7 @@ function makeManagedProcess(
     logicalFailure: false,
     turnSettled: false,
     metaTurn: false,
+    keepAlive: false,
     lastActivityAt: new Date(),
     slashCommands: [],
     agents: [],
@@ -227,7 +228,7 @@ describe('gcSweep — stream stall detection', () => {
   })
 
   test('does NOT kill idle process within IDLE_TIMEOUT_MS', () => {
-    const recentIdle = new Date(Date.now() - 5 * 60_000) // 5 min ago
+    const recentIdle = new Date(Date.now() - 4 * 60_000) // 4 min ago (within 5 min timeout)
     const managed = makeManagedProcess({
       issueId: 'issue-5',
       executionId: 'exec-5',
@@ -240,6 +241,23 @@ describe('gcSweep — stream stall detection', () => {
     gcSweep(ctx)
 
     expect(forceKillCalls).not.toContain('exec-5')
+  })
+
+  test('keepAlive prevents idle timeout termination', () => {
+    const idleAt = new Date(Date.now() - IDLE_TIMEOUT_MS - 60_000) // past idle timeout
+    const managed = makeManagedProcess({
+      issueId: 'issue-ka',
+      executionId: 'exec-ka',
+      turnInFlight: false,
+      keepAlive: true,
+      lastIdleAt: idleAt,
+      lastActivityAt: idleAt,
+    })
+    const { ctx, forceKillCalls } = makeContext([{ id: 'exec-ka', meta: managed }])
+
+    gcSweep(ctx)
+
+    expect(forceKillCalls).not.toContain('exec-ka')
   })
 
   test('handles multiple processes — detects stalled, skips active and idle', () => {

--- a/apps/api/test/turn-completion-regression.test.ts
+++ b/apps/api/test/turn-completion-regression.test.ts
@@ -86,6 +86,7 @@ describe('turn completion pending-flush regression', () => {
       slashCommands: [],
       agents: [],
       plugins: [],
+      keepAlive: false,
       lastActivityAt: new Date(),
       pendingInputs: [],
     }

--- a/apps/frontend/src/components/issue-detail/IssueDetail.tsx
+++ b/apps/frontend/src/components/issue-detail/IssueDetail.tsx
@@ -1,7 +1,8 @@
-import { ChevronDown, GitBranch, Tag, Trash2 } from 'lucide-react'
+import { ChevronDown, GitBranch, Tag, Trash2, Zap } from 'lucide-react'
 import { useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
 import { useClickOutside } from '@/hooks/use-click-outside'
 import { useProjectWorktrees } from '@/hooks/use-kanban'
 import { tStatus } from '@/lib/i18n-utils'
@@ -25,7 +26,7 @@ export function IssueDetail({
   issue: Issue
   projectId?: string
   status?: StatusDefinition
-  onUpdate?: (fields: Partial<Pick<Issue, 'statusId' | 'tags'>>) => void
+  onUpdate?: (fields: Partial<Pick<Issue, 'statusId' | 'tags' | 'keepAlive'>>) => void
   onDelete?: () => void
   isDeleting?: boolean
 }) {
@@ -49,6 +50,23 @@ export function IssueDetail({
     <div className="shrink-0 relative z-20 flex items-center gap-1.5 px-4 py-1.5 border-t border-border/40 bg-muted/20">
       {/* Status — editable */}
       <StatusSelect status={status} onChange={id => onUpdate?.({ statusId: id })} />
+
+      {/* Keep Alive */}
+      <label
+        className={`${badgeBase} cursor-pointer transition-colors ${
+          issue.keepAlive
+            ? 'border-amber-400/40 bg-amber-500/10 text-amber-600 dark:text-amber-400'
+            : 'border-border/50 bg-muted/20 text-muted-foreground/40'
+        }`}
+        title={t('issue.keepAlive')}
+      >
+        <Zap className="h-3 w-3" />
+        <Switch
+          size="sm"
+          checked={issue.keepAlive}
+          onCheckedChange={v => onUpdate?.({ keepAlive: !!v })}
+        />
+      </label>
 
       {/* Delete */}
       {onDelete ?

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -109,7 +109,8 @@
     "delete": "Delete",
     "deleteConfirm": "Are you sure you want to delete this issue? This action cannot be undone.",
     "deleteWithChildren": "This issue has sub-issues that will also be deleted.",
-    "deleting": "Deleting..."
+    "deleting": "Deleting...",
+    "keepAlive": "Keep Alive — prevent idle timeout from terminating the process"
   },
   "createIssue": {
     "model": "Model",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -109,7 +109,8 @@
     "delete": "删除",
     "deleteConfirm": "确定要删除此任务吗？此操作无法撤销。",
     "deleteWithChildren": "此任务包含子任务，子任务也将一并删除。",
-    "deleting": "删除中..."
+    "deleting": "删除中...",
+    "keepAlive": "保持活跃 — 防止空闲超时自动终止进程"
   },
   "createIssue": {
     "model": "模型",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,6 +40,7 @@ export interface Issue {
   sortOrder: string
   useWorktree: boolean
   isPinned: boolean
+  keepAlive: boolean
   engineType: EngineType | null
   sessionStatus: SessionStatus | null
   prompt: string | null


### PR DESCRIPTION
## Summary

- Add a `keepAlive` boolean field to issues that prevents the 5-minute idle timeout from terminating the process
- Toggle switch (Zap icon) in the chat area metadata bar, before the delete button
- GC sweep skips idle timeout termination for keepAlive issues while preserving stall detection for all processes

## Changes

**Backend:**
- `keep_alive` column added to `issues` table (migration 0013)
- Zod schemas updated for create/update routes
- `gcSweep` made async — queries DB for keepAlive flag before idle termination
- keepAlive only suppresses idle timeout, not stall detection (no `continue` bypass)

**Frontend:**
- Switch toggle with amber highlight when active in `IssueDetail`
- i18n keys added for en/zh

## Test plan

- [ ] Create an issue, toggle keepAlive on, verify it persists after refresh
- [ ] Run an issue with keepAlive on, let it idle > 5 min, verify process stays alive
- [ ] Run an issue with keepAlive off, let it idle > 5 min, verify process is terminated
- [ ] Verify stall detection still works for keepAlive issues (stalled turn-in-flight)
- [ ] Verify migration applies cleanly on fresh and existing databases