### PR TITLE
fix: restrict Vite dev server allowedHosts

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -90,7 +90,13 @@ const config = defineConfig(() => {
     server: {
       port: devPort,
       host: devHost,
-      allowedHosts: true,
+      // Restrict allowed hosts to prevent DNS rebinding attacks.
+      // Extend via VITE_ALLOWED_HOSTS (comma-separated) for custom domains.
+      allowedHosts: [
+        'localhost',
+        '127.0.0.1',
+        ...(process.env.VITE_ALLOWED_HOSTS?.split(',').map(h => h.trim()).filter(Boolean) ?? []),
+      ],
       proxy: {
         '/api': {
           target: `http://localhost:${apiPort}`,

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -79,7 +79,7 @@
 - [ ] **AUDIT-068 Compile script mutates tracked source files in place** `P2`
 - [ ] **AUDIT-069 CI/release workflow actions not pinned to SHA** `P2`
 - [ ] **AUDIT-070 Upload cleanup symlinks could cause out-of-directory deletion** `P2`
-- [ ] **AUDIT-071 Vite dev server allowedHosts:true disables host validation** `P2`
+- [x] **AUDIT-071 Vite dev server allowedHosts:true disables host validation** `P2`
 - [ ] **AUDIT-072 No GitHub API rate limit handling in upgrade checker** `P2`
 
 ## Audit — LOW (P3)


### PR DESCRIPTION
## Summary
- Replace `allowedHosts: true` with explicit `['localhost', '127.0.0.1']` to prevent DNS rebinding attacks on the Vite dev server
- Support `VITE_ALLOWED_HOSTS` env var (comma-separated) for custom domain overrides
- Closes AUDIT-071

## Test plan
- [ ] Run `bun run dev:frontend` — dev server starts and is accessible at `http://localhost:3000`
- [ ] Access via `http://127.0.0.1:3000` — works
- [ ] Access via machine IP or arbitrary hostname — blocked by Vite
- [ ] Set `VITE_ALLOWED_HOSTS=myhost.local` and verify that hostname is accepted