### PR TITLE
fix: address audit follow-up CI issues

### DIFF
--- a/apps/api/src/routes/issues/_shared.ts
+++ b/apps/api/src/routes/issues/_shared.ts
@@ -46,6 +46,20 @@ export const bulkUpdateSchema = z.object({
         sortOrder: z.string().min(1).max(50).regex(fractionalKeyRegex).optional(),
       }),
     )
+    .superRefine((updates, ctx) => {
+      const seen = new Set<string>()
+      for (const [index, update] of updates.entries()) {
+        if (seen.has(update.id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Duplicate issue id in bulk updates',
+            path: [index, 'id'],
+          })
+          continue
+        }
+        seen.add(update.id)
+      }
+    })
     .max(1000),
 })
 

--- a/apps/api/test/api-issues.test.ts
+++ b/apps/api/test/api-issues.test.ts
@@ -298,6 +298,28 @@ describe('PATCH /api/projects/:projectId/issues/bulk', () => {
     expect(Array.isArray(data)).toBe(true)
     expect(data.length).toBe(2)
   })
+
+  test('rejects duplicate issue ids in a single bulk payload', async () => {
+    const issue = expectSuccess(
+      await post<Issue>(`/api/projects/${projectId}/issues`, {
+        title: 'Bulk Duplicate',
+        statusId: 'todo',
+      }),
+    )
+
+    const result = await patch<Issue[]>(`/api/projects/${projectId}/issues/bulk`, {
+      updates: [
+        { id: issue.id, statusId: 'working', sortOrder: 'a0' },
+        { id: issue.id, statusId: 'done', sortOrder: 'a1' },
+      ],
+    })
+
+    expect(result.status).toBe(400)
+    expect(result.json.success).toBe(false)
+    if (!result.json.success) {
+      expect(result.json.error).toContain('Duplicate issue id in bulk updates')
+    }
+  })
 })
 
 describe('DELETE /api/projects/:projectId/issues/:id', () => {

--- a/apps/api/test/safe-env.test.ts
+++ b/apps/api/test/safe-env.test.ts
@@ -2,6 +2,14 @@ import process from 'node:process'
 import { beforeAll, describe, expect, test } from 'bun:test'
 import { safeEnv } from '@/engines/safe-env'
 
+function requireProcessEnv(key: 'PATH' | 'HOME'): string {
+  const value = process.env[key]
+  if (!value) {
+    throw new Error(`${key} must be set for safeEnv tests`)
+  }
+  return value
+}
+
 // Ensure test API keys are set so we can verify filtering
 beforeAll(() => {
   process.env.ANTHROPIC_API_KEY = 'test-anthropic-key'
@@ -15,13 +23,13 @@ describe('safeEnv', () => {
   describe('protected key filtering', () => {
     test('blocks user-supplied PATH override', () => {
       const env = safeEnv({ PATH: '/malicious/bin' })
-      expect(env.PATH).toBe(process.env.PATH)
+      expect(env.PATH).toBe(requireProcessEnv('PATH'))
       expect(env.PATH).not.toBe('/malicious/bin')
     })
 
     test('blocks user-supplied HOME override', () => {
       const env = safeEnv({ HOME: '/tmp/evil' })
-      expect(env.HOME).toBe(process.env.HOME)
+      expect(env.HOME).toBe(requireProcessEnv('HOME'))
     })
 
     test('blocks user-supplied ANTHROPIC_API_KEY override', () => {
@@ -54,8 +62,8 @@ describe('safeEnv', () => {
         ANTHROPIC_API_KEY: 'evil',
         SAFE_VAR: 'allowed',
       })
-      expect(env.PATH).toBe(process.env.PATH)
-      expect(env.HOME).toBe(process.env.HOME)
+      expect(env.PATH).toBe(requireProcessEnv('PATH'))
+      expect(env.HOME).toBe(requireProcessEnv('HOME'))
       expect(env.ANTHROPIC_API_KEY).toBe('test-anthropic-key')
       expect(env.SAFE_VAR).toBe('allowed')
     })
@@ -111,8 +119,8 @@ describe('safeEnv', () => {
   describe('basic allowlisting', () => {
     test('includes PATH and HOME from process.env', () => {
       const env = safeEnv()
-      expect(env.PATH).toBe(process.env.PATH)
-      expect(env.HOME).toBe(process.env.HOME)
+      expect(env.PATH).toBe(requireProcessEnv('PATH'))
+      expect(env.HOME).toBe(requireProcessEnv('HOME'))
     })
 
     test('excludes non-allowlisted process.env vars', () => {

--- a/apps/api/test/security-headers.test.ts
+++ b/apps/api/test/security-headers.test.ts
@@ -17,14 +17,14 @@ describe('Content-Security-Policy (SEC-019)', () => {
     const res = await requestHeaders('/api/projects')
     const csp = res.headers.get('content-security-policy')
     expect(csp).toBeTruthy()
-    expect(csp).toContain("default-src 'self'")
-    expect(csp).toContain("script-src 'self' 'unsafe-inline'")
-    expect(csp).toContain("style-src 'self' 'unsafe-inline'")
-    expect(csp).toContain("img-src 'self' data: blob:")
-    expect(csp).toContain("connect-src 'self'")
-    expect(csp).toContain("font-src 'self'")
-    expect(csp).toContain("frame-ancestors 'none'")
-    expect(csp).toContain("object-src 'none'")
+    expect(csp).toContain('default-src \'self\'')
+    expect(csp).toContain('script-src \'self\' \'unsafe-inline\'')
+    expect(csp).toContain('style-src \'self\' \'unsafe-inline\'')
+    expect(csp).toContain('img-src \'self\' data: blob:')
+    expect(csp).toContain('connect-src \'self\'')
+    expect(csp).toContain('font-src \'self\'')
+    expect(csp).toContain('frame-ancestors \'none\'')
+    expect(csp).toContain('object-src \'none\'')
   })
 })
 
@@ -57,7 +57,7 @@ describe('CORS (SEC-002)', () => {
   test('returns CORS headers on normal API requests', async () => {
     const res = await requestHeaders('/api/projects', {
       method: 'GET',
-      headers: { 'Origin': 'http://localhost:3000' },
+      headers: { Origin: 'http://localhost:3000' },
     })
     const acao = res.headers.get('access-control-allow-origin')
     expect(acao).toBe('*')
@@ -66,7 +66,7 @@ describe('CORS (SEC-002)', () => {
   test('does not return CORS headers for non-API paths', async () => {
     const res = await requestHeaders('/', {
       method: 'GET',
-      headers: { 'Origin': 'http://localhost:3000' },
+      headers: { Origin: 'http://localhost:3000' },
     })
     const acao = res.headers.get('access-control-allow-origin')
     expect(acao).toBeNull()

--- a/apps/frontend/src/__tests__/hooks/use-auth.test.tsx
+++ b/apps/frontend/src/__tests__/hooks/use-auth.test.tsx
@@ -57,7 +57,7 @@ function ProtectedApp() {
   )
 }
 
-describe('AuthGate fail-closed behaviour', () => {
+describe('authGate fail-closed behaviour', () => {
   beforeEach(() => {
     vi.mocked(getToken).mockReturnValue(null)
   })

--- a/apps/frontend/src/__tests__/lib/event-bus.test.ts
+++ b/apps/frontend/src/__tests__/lib/event-bus.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-let getTokenMock: ReturnType<typeof vi.fn>
+const { getTokenMock } = vi.hoisted(() => ({
+  getTokenMock: vi.fn<() => string | null>(),
+}))
 
 vi.mock('@/lib/auth', () => ({
-  getToken: (...args: unknown[]) => getTokenMock(...args),
+  getToken: getTokenMock,
 }))
 
 // Minimal EventSource stub
@@ -54,7 +56,8 @@ describe('eventBus', () => {
 
   beforeEach(async () => {
     vi.useFakeTimers()
-    getTokenMock = vi.fn().mockReturnValue(null)
+    getTokenMock.mockReset()
+    getTokenMock.mockReturnValue(null)
     MockEventSource.reset()
 
     // Stub global EventSource

--- a/apps/frontend/src/components/issue-detail/SessionMessages.tsx
+++ b/apps/frontend/src/components/issue-detail/SessionMessages.tsx
@@ -11,7 +11,7 @@ import { ToolGroupMessage } from './ToolItems'
 
 // ── ChatMessage renderer ─────────────────────────────────
 
-const ChatMessageRow = memo(function ChatMessageRow({ message }: { message: ChatMessage }) {
+const ChatMessageRow = memo(({ message }: { message: ChatMessage }) => {
   switch (message.type) {
     case 'user': {
       if (message.status === 'command') {

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -32,7 +32,9 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
     await Bun.write(tmp, content)
     renameSync(tmp, filePath)
   } catch (err) {
-    try { unlinkSync(tmp) } catch {}
+    try {
+      unlinkSync(tmp)
+    } catch {}
     throw err
   }
 }
@@ -180,11 +182,15 @@ if (compileMode === 'launcher') {
   function restoreStubFiles() {
     if (existsSync(STATIC_BACKUP)) {
       copyFileSync(STATIC_BACKUP, STATIC_FILE)
-      try { unlinkSync(STATIC_BACKUP) } catch {}
+      try {
+        unlinkSync(STATIC_BACKUP)
+      } catch {}
     }
     if (existsSync(MIGRATIONS_BACKUP)) {
       copyFileSync(MIGRATIONS_BACKUP, MIGRATIONS_FILE)
-      try { unlinkSync(MIGRATIONS_BACKUP) } catch {}
+      try {
+        unlinkSync(MIGRATIONS_BACKUP)
+      } catch {}
     }
   }
 

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -28,7 +28,9 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
     await Bun.write(tmp, content)
     renameSync(tmp, filePath)
   } catch (err) {
-    try { unlinkSync(tmp) } catch {}
+    try {
+      unlinkSync(tmp)
+    } catch {}
     throw err
   }
 }


### PR DESCRIPTION
## Summary
- reject duplicate issue ids in bulk issue updates to avoid duplicate auto-execution side effects
- fix the remaining typecheck and lint regressions introduced around the audit remediation merge
- add regression coverage for duplicate bulk ids and stabilize the affected frontend test mocks

## Verification
- bunx tsc --noEmit -p apps/api/tsconfig.json && bunx tsc --noEmit -p apps/frontend/tsconfig.json
- bun run lint
- bun test apps/api/test/api-issues.test.ts apps/api/test/safe-env.test.ts apps/api/test/security-headers.test.ts
- cd apps/frontend && bunx vitest run src/__tests__/lib/event-bus.test.ts src/__tests__/hooks/use-auth.test.tsx