### PR TITLE
fix: detect oversized files and skip git diff to prevent hang

### DIFF
--- a/apps/api/src/engines/spawn.ts
+++ b/apps/api/src/engines/spawn.ts
@@ -195,6 +195,8 @@ export interface CommandResult {
   code: number
   stdout: string
   stderr: string
+  /** true when the process was killed because it exceeded the timeout */
+  timedOut?: boolean
 }
 
 /**
@@ -223,8 +225,10 @@ export async function runCommand(
 
   // Kill the child if it exceeds the timeout deadline
   let killTimer: ReturnType<typeof setTimeout> | undefined
+  let didTimeout = false
   if (options?.timeout) {
     killTimer = setTimeout(() => {
+      didTimeout = true
       try {
         child.kill()
       } catch { /* already dead */ }
@@ -250,6 +254,7 @@ export async function runCommand(
     code,
     stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
     stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+    ...(didTimeout ? { timedOut: true } : {}),
   }
 }
 

--- a/apps/api/src/events/changes-summary.ts
+++ b/apps/api/src/events/changes-summary.ts
@@ -7,7 +7,7 @@ import { findProject } from '@/db/helpers'
 import { issues as issuesTable } from '@/db/schema'
 import { appEvents } from '@/events'
 import { logger } from '@/logger'
-import { countTextLines, isPathInsideRoot, resolveIssueDir } from '@/utils/changes'
+import { countTextLines, isPathInsideRoot, LARGE_FILE_THRESHOLD, resolveIssueDir } from '@/utils/changes'
 
 export type { ChangesSummary } from '@bkd/shared'
 
@@ -104,7 +104,7 @@ async function computeAndEmit(issueId: string): Promise<void> {
 
       // Untracked files — count lines manually (git diff HEAD ignores them).
       // `-uall` ensures individual files are listed, but guard against
-      // directory entries and binary/unreadable files defensively.
+      // directory entries, binary/unreadable files, and oversized files defensively.
       for (const { path, isUntracked } of statusLines) {
         if (!isUntracked) continue
         if (!isPathInsideRoot(root, path)) continue
@@ -112,6 +112,7 @@ async function computeAndEmit(issueId: string): Promise<void> {
           const fullPath = resolve(root, path)
           const s = await stat(fullPath)
           if (!s.isFile()) continue
+          if (s.size > LARGE_FILE_THRESHOLD) continue // skip oversized files
           const content = await Bun.file(fullPath).text()
           additions += countTextLines(content)
         } catch {

--- a/apps/api/src/routes/issues/changes.ts
+++ b/apps/api/src/routes/issues/changes.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { runCommand } from '@/engines/spawn'
 import { Hono } from 'hono'
 import { findProject } from '@/db/helpers'
-import { countTextLines, isPathInsideRoot, resolveIssueDir } from '@/utils/changes'
+import { checkOversized, countTextLines, isPathInsideRoot, resolveIssueDir } from '@/utils/changes'
 import { isGitRepo } from '@/utils/git'
 import { getProjectOwnedIssue } from './_shared'
 
@@ -20,6 +20,10 @@ interface GitChangedFile {
   previousPath?: string
   additions?: number
   deletions?: number
+  /** true when the file exceeds the large-file threshold (20 MB) */
+  oversized?: boolean
+  /** human-readable file size (only set when oversized) */
+  sizeDisplay?: string
 }
 
 // ---------- Git helpers ----------
@@ -41,7 +45,7 @@ async function runGit(
   args: string[],
   cwd: string,
 ): Promise<{ code: number, stdout: string }> {
-  return runCommand(['git', ...args], { cwd })
+  return runCommand(['git', ...args], { cwd, timeout: 15_000 })
 }
 
 function parsePorcelainLine(line: string): GitChangedFile | null {
@@ -70,19 +74,28 @@ function parsePorcelainLine(line: string): GitChangedFile | null {
 async function listChangedFiles(cwd: string): Promise<GitChangedFile[]> {
   const { code, stdout } = await runGit(['status', '--porcelain=v1', '-uall'], cwd)
   if (code !== 0) return []
-  return stdout
+  const parsed = stdout
     .split('\n')
     .map(line => line.trimEnd())
     .filter(Boolean)
     .map(parsePorcelainLine)
     .filter((f): f is GitChangedFile => !!f)
     .sort((a, b) => a.path.localeCompare(b.path))
+
+  // Check file sizes in parallel and merge oversized flags (immutable)
+  const sizeFlags = await Promise.all(
+    parsed.map(file => checkOversized(cwd, file.path)),
+  )
+  return parsed.map((file, i) => sizeFlags[i] ? { ...file, ...sizeFlags[i] } : file)
 }
 
 async function summarizeFileLines(
   cwd: string,
   file: GitChangedFile,
 ): Promise<{ additions: number, deletions: number }> {
+  // Skip diff for oversized files — they would block the event loop or OOM
+  if (file.oversized) return { additions: 0, deletions: 0 }
+
   if (file.type === 'untracked') {
     if (!isPathInsideRoot(cwd, file.path)) return { additions: 0, deletions: 0 }
     try {
@@ -208,6 +221,24 @@ changes.get('/:id/changes/file', async (c) => {
     return c.json({
       success: true,
       data: { path, patch: '', truncated: false },
+    })
+  }
+
+  // Refuse to diff oversized files
+  if (file.oversized) {
+    return c.json({
+      success: true,
+      data: {
+        path,
+        patch: '',
+        oldText: '',
+        newText: '',
+        truncated: false,
+        type: file.type,
+        status: file.status,
+        oversized: true,
+        sizeDisplay: file.sizeDisplay,
+      },
     })
   }
 

--- a/apps/api/src/routes/issues/changes.ts
+++ b/apps/api/src/routes/issues/changes.ts
@@ -225,7 +225,13 @@ changes.get('/:id/changes/file', async (c) => {
     })
   }
 
-  const { files: changedFiles } = await listChangedFiles(root)
+  const { files: changedFiles, timedOut: listTimedOut } = await listChangedFiles(root)
+  if (listTimedOut) {
+    return c.json({
+      success: true,
+      data: { path, patch: '', truncated: false, timedOut: true },
+    })
+  }
   const file = changedFiles.find(f => f.path === path)
   if (!file) {
     return c.json({

--- a/apps/api/src/routes/issues/changes.ts
+++ b/apps/api/src/routes/issues/changes.ts
@@ -44,7 +44,7 @@ async function resolveProjectDir(projectId: string): Promise<string | null> {
 async function runGit(
   args: string[],
   cwd: string,
-): Promise<{ code: number, stdout: string }> {
+): Promise<{ code: number, stdout: string, timedOut?: boolean }> {
   return runCommand(['git', ...args], { cwd, timeout: 15_000 })
 }
 
@@ -71,9 +71,11 @@ function parsePorcelainLine(line: string): GitChangedFile | null {
   return { path, status, type, staged, unstaged, previousPath }
 }
 
-async function listChangedFiles(cwd: string): Promise<GitChangedFile[]> {
-  const { code, stdout } = await runGit(['status', '--porcelain=v1', '-uall'], cwd)
-  if (code !== 0) return []
+async function listChangedFiles(cwd: string): Promise<{ files: GitChangedFile[], timedOut?: boolean }> {
+  const result = await runGit(['status', '--porcelain=v1', '-uall'], cwd)
+  if (result.timedOut) return { files: [], timedOut: true }
+  if (result.code !== 0) return { files: [] }
+  const { stdout } = result
   const parsed = stdout
     .split('\n')
     .map(line => line.trimEnd())
@@ -86,7 +88,8 @@ async function listChangedFiles(cwd: string): Promise<GitChangedFile[]> {
   const sizeFlags = await Promise.all(
     parsed.map(file => checkOversized(cwd, file.path)),
   )
-  return parsed.map((file, i) => sizeFlags[i] ? { ...file, ...sizeFlags[i] } : file)
+  const files = parsed.map((file, i) => sizeFlags[i] ? { ...file, ...sizeFlags[i] } : file)
+  return { files }
 }
 
 async function summarizeFileLines(
@@ -159,7 +162,14 @@ changes.get('/:id/changes', async (c) => {
     })
   }
 
-  const files = await listChangedFiles(root)
+  const { files, timedOut } = await listChangedFiles(root)
+
+  if (timedOut) {
+    return c.json({
+      success: true,
+      data: { root, gitRepo: true, files: [], additions: 0, deletions: 0, timedOut: true },
+    })
+  }
 
   const filesWithStats = await Promise.all(
     files.map(async file => ({
@@ -215,7 +225,7 @@ changes.get('/:id/changes/file', async (c) => {
     })
   }
 
-  const changedFiles = await listChangedFiles(root)
+  const { files: changedFiles } = await listChangedFiles(root)
   const file = changedFiles.find(f => f.path === path)
   if (!file) {
     return c.json({

--- a/apps/api/src/utils/changes.ts
+++ b/apps/api/src/utils/changes.ts
@@ -1,6 +1,36 @@
-import { stat } from 'node:fs/promises'
+import { lstat, stat } from 'node:fs/promises'
 import { resolve, sep } from 'node:path'
 import { resolveWorktreePath } from '@/engines/issue/utils/worktree'
+
+/** Files larger than this threshold are flagged as oversized and skipped for diff */
+export const LARGE_FILE_THRESHOLD = 20 * 1024 * 1024 // 20 MB
+
+export function formatFileSize(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${bytes} B`
+}
+
+/**
+ * Check file size using lstat (does not follow symlinks).
+ * Returns `{ oversized, sizeDisplay }` when the file exceeds the threshold.
+ */
+export async function checkOversized(
+  root: string,
+  relPath: string,
+): Promise<{ oversized: true, sizeDisplay: string } | null> {
+  if (!isPathInsideRoot(root, relPath)) return null
+  try {
+    const s = await lstat(resolve(root, relPath))
+    if (s.isFile() && s.size > LARGE_FILE_THRESHOLD) {
+      return { oversized: true, sizeDisplay: formatFileSize(s.size) }
+    }
+  } catch {
+    // file may have been deleted — that's fine
+  }
+  return null
+}
 
 /**
  * Returns true when `path` (relative to `root`) resolves inside the `root` directory.

--- a/apps/frontend/src/components/issue-detail/DiffPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/DiffPanel.tsx
@@ -126,30 +126,41 @@ export function DiffPanel({
                       </span>
                     </div>
                   ) :
-                files.length === 0 ?
+                changesQuery.data?.timedOut ?
                     (
                       <div className="flex-1 flex items-center justify-center px-4">
-                        <span className="text-sm text-muted-foreground text-center">{t('diff.noChanges')}</span>
+                        <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 max-w-xs">
+                          <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
+                          <span className="text-sm text-amber-700 dark:text-amber-300">
+                            {t('diff.timedOut')}
+                          </span>
+                        </div>
                       </div>
                     ) :
-                    (
-                      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-y-contain touch-pan-y p-2 space-y-2">
-                        <OversizedFilesBanner files={files} />
-                        {files.map(file => (
-                          <DiffFileCard
-                            key={file.path}
-                            projectId={projectId}
-                            issueId={issueId}
-                            path={file.path}
-                            type={file.type}
-                            additions={file.additions}
-                            deletions={file.deletions}
-                            oversized={file.oversized}
-                            sizeDisplay={file.sizeDisplay}
-                          />
-                        ))}
-                      </div>
-                    )}
+                  files.length === 0 ?
+                      (
+                        <div className="flex-1 flex items-center justify-center px-4">
+                          <span className="text-sm text-muted-foreground text-center">{t('diff.noChanges')}</span>
+                        </div>
+                      ) :
+                      (
+                        <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-y-contain touch-pan-y p-2 space-y-2">
+                          <OversizedFilesBanner files={files} />
+                          {files.map(file => (
+                            <DiffFileCard
+                              key={file.path}
+                              projectId={projectId}
+                              issueId={issueId}
+                              path={file.path}
+                              type={file.type}
+                              additions={file.additions}
+                              deletions={file.deletions}
+                              oversized={file.oversized}
+                              sizeDisplay={file.sizeDisplay}
+                            />
+                          ))}
+                        </div>
+                      )}
       </div>
     </div>
   )

--- a/apps/frontend/src/components/issue-detail/DiffPanel.tsx
+++ b/apps/frontend/src/components/issue-detail/DiffPanel.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Copy, X } from 'lucide-react'
+import { AlertTriangle, ChevronRight, Copy, X } from 'lucide-react'
 import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useIssueChanges, useIssueFilePatch } from '@/hooks/use-kanban'
@@ -134,6 +134,7 @@ export function DiffPanel({
                     ) :
                     (
                       <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-y-contain touch-pan-y p-2 space-y-2">
+                        <OversizedFilesBanner files={files} />
                         {files.map(file => (
                           <DiffFileCard
                             key={file.path}
@@ -143,6 +144,8 @@ export function DiffPanel({
                             type={file.type}
                             additions={file.additions}
                             deletions={file.deletions}
+                            oversized={file.oversized}
+                            sizeDisplay={file.sizeDisplay}
                           />
                         ))}
                       </div>
@@ -154,6 +157,38 @@ export function DiffPanel({
 
 export { DIFF_MIN_WIDTH }
 
+function OversizedFilesBanner({ files }: { files: IssueChangedFile[] }) {
+  const { t } = useTranslation()
+  const oversizedFiles = useMemo(() => files.filter(f => f.oversized), [files])
+  if (oversizedFiles.length === 0) return null
+
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5">
+      <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
+      <div className="min-w-0 text-[12px] text-amber-700 dark:text-amber-300">
+        <p className="font-semibold">{t('diff.oversizedBannerTitle')}</p>
+        <ul className="mt-1 space-y-0.5 list-disc list-inside">
+          {oversizedFiles.map(f => (
+            <li key={f.path} className="truncate">
+              <span className="font-mono text-[11px]">{f.path}</span>
+              {f.sizeDisplay ? (
+                <span className="ml-1 text-amber-600/70 dark:text-amber-400/70">
+                  (
+                  {f.sizeDisplay}
+                  )
+                </span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+        <p className="mt-1.5 text-amber-600/80 dark:text-amber-400/80 text-[11px]">
+          {t('diff.oversizedBannerHint')}
+        </p>
+      </div>
+    </div>
+  )
+}
+
 function DiffFileCard({
   projectId,
   issueId,
@@ -161,6 +196,8 @@ function DiffFileCard({
   type,
   additions,
   deletions,
+  oversized,
+  sizeDisplay,
 }: {
   projectId: string
   issueId: string
@@ -168,12 +205,14 @@ function DiffFileCard({
   type: FileType
   additions?: number
   deletions?: number
+  oversized?: boolean
+  sizeDisplay?: string
 }) {
   const { t } = useTranslation()
   const { resolved } = useTheme()
   const [isOpen, setIsOpen] = useState(false)
   const [copied, setCopied] = useState(false)
-  const patchQuery = useIssueFilePatch(projectId, issueId, path, isOpen)
+  const patchQuery = useIssueFilePatch(projectId, issueId, path, isOpen && !oversized)
   const patch = patchQuery.data
   const patchText = patch?.patch ?? ''
   const stats = useMemo(() => getPatchStats(patchText), [patchText])
@@ -214,6 +253,13 @@ function DiffFileCard({
           <span className="min-w-0 truncate text-[12.5px] font-medium">{path}</span>
           <div className="ml-auto flex shrink-0 items-center gap-1.5">
             <FileTypeBadge type={type} />
+            {oversized
+              ? (
+                  <span className="shrink-0 text-[10px] font-semibold leading-none text-amber-600 dark:text-amber-400 border border-amber-500/30 bg-amber-500/10 rounded px-1 py-0.5">
+                    {sizeDisplay ?? t('diff.oversized')}
+                  </span>
+                )
+              : null}
             <button
               type="button"
               onClick={handleCopyPath}
@@ -223,82 +269,92 @@ function DiffFileCard({
             >
               <Copy className={`h-3 w-3 ${copied ? 'text-emerald-500' : ''}`} />
             </button>
-            <span className="flex items-center gap-0.5 text-[11px] font-medium tabular-nums">
-              {displayAdditions > 0 ?
-                  (
-                    <span className="text-emerald-600 dark:text-emerald-400">
-                      +
-                      {displayAdditions}
-                    </span>
-                  ) :
-                null}
-              {displayDeletions > 0 ?
-                  (
-                    <span className="text-red-600 dark:text-red-400">
-                      -
-                      {displayDeletions}
-                    </span>
-                  ) :
-                null}
-            </span>
+            {!oversized
+              ? (
+                  <span className="flex items-center gap-0.5 text-[11px] font-medium tabular-nums">
+                    {displayAdditions > 0 ?
+                        (
+                          <span className="text-emerald-600 dark:text-emerald-400">
+                            +
+                            {displayAdditions}
+                          </span>
+                        ) :
+                      null}
+                    {displayDeletions > 0 ?
+                        (
+                          <span className="text-red-600 dark:text-red-400">
+                            -
+                            {displayDeletions}
+                          </span>
+                        ) :
+                      null}
+                  </span>
+                )
+              : null}
           </div>
         </div>
       </summary>
       {isOpen ?
           (
             <div className="min-w-0 border-t border-border/30">
-              {patchQuery.isLoading ?
+              {oversized ?
                   (
-                    <div className="px-3 py-2.5 text-[11px] text-muted-foreground">
-                      {t('common.loading')}
+                    <div className="px-3 py-3 text-[11px] text-amber-600 dark:text-amber-400 bg-amber-500/5">
+                      {t('diff.oversizedMessage', { size: sizeDisplay ?? '> 20 MB' })}
                     </div>
                   ) :
-                patchQuery.isError ?
+                patchQuery.isLoading ?
                     (
-                      <div className="px-3 py-2.5 text-[11px] text-destructive">
-                        {String(patchQuery.error.message || t('diff.loadFailed'))}
+                      <div className="px-3 py-2.5 text-[11px] text-muted-foreground">
+                        {t('common.loading')}
                       </div>
                     ) :
-                  fullFilePair ?
+                  patchQuery.isError ?
                       (
-                        <div className="overflow-x-auto">
-                          <Suspense
-                            fallback={(
-                              <div className="px-3 py-2.5 text-[11px] text-muted-foreground">
-                                {t('common.loading')}
-                              </div>
-                            )}
-                          >
-                            <LazyMultiFileDiff
-                              oldFile={{ name: path, contents: fullFilePair.oldText }}
-                              newFile={{ name: path, contents: fullFilePair.newText }}
-                              options={{
-                                diffStyle: 'unified',
-                                diffIndicators: 'bars',
-                                expandUnchanged: false,
-                                hunkSeparators: 'line-info',
-                                disableLineNumbers: false,
-                                overflow: 'wrap',
-                                theme: {
-                                  light: 'github-light-default',
-                                  dark: 'github-dark-default',
-                                },
-                                themeType,
-                                disableFileHeader: true,
-                              }}
-                            />
-                          </Suspense>
+                        <div className="px-3 py-2.5 text-[11px] text-destructive">
+                          {String(patchQuery.error.message || t('diff.loadFailed'))}
                         </div>
                       ) :
-                    patchText.trim() ?
+                    fullFilePair ?
                         (
-                          <PatchDiffView patch={patchText} />
-                        ) :
-                        (
-                          <div className="px-3 py-2.5 text-[11px] text-muted-foreground">
-                            {t('diff.emptyPatch')}
+                          <div className="overflow-x-auto">
+                            <Suspense
+                              fallback={(
+                                <div className="px-3 py-2.5 text-[11px] text-muted-foreground">
+                                  {t('common.loading')}
+                                </div>
+                              )}
+                            >
+                              <LazyMultiFileDiff
+                                oldFile={{ name: path, contents: fullFilePair.oldText }}
+                                newFile={{ name: path, contents: fullFilePair.newText }}
+                                options={{
+                                  diffStyle: 'unified',
+                                  diffIndicators: 'bars',
+                                  expandUnchanged: false,
+                                  hunkSeparators: 'line-info',
+                                  disableLineNumbers: false,
+                                  overflow: 'wrap',
+                                  theme: {
+                                    light: 'github-light-default',
+                                    dark: 'github-dark-default',
+                                  },
+                                  themeType,
+                                  disableFileHeader: true,
+                                }}
+                              />
+                            </Suspense>
                           </div>
-                        )}
+                        ) :
+                      patchText.trim() ?
+                          (
+                            <PatchDiffView patch={patchText} />
+                          ) :
+                          (
+                            <div className="px-3 py-2.5 text-[11px] text-muted-foreground">
+                              {t('diff.emptyPatch')}
+                            </div>
+                          )}
               {patch?.truncated ?
                   (
                     <div className="px-3 pb-2 text-[11px] text-muted-foreground">{t('diff.truncated')}</div>

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -197,7 +197,11 @@
       "new": "New",
       "deleted": "Del",
       "renamed": "Ren"
-    }
+    },
+    "oversized": "Large file",
+    "oversizedMessage": "This file ({{size}}) exceeds 20 MB and diff is skipped to avoid blocking the system.",
+    "oversizedBannerTitle": "Large files detected — review before committing",
+    "oversizedBannerHint": "Consider adding these files to .gitignore to avoid bloating the repository."
   },
   "session": {
     "connected": "Connected",

--- a/apps/frontend/src/i18n/en.json
+++ b/apps/frontend/src/i18n/en.json
@@ -201,7 +201,8 @@
     "oversized": "Large file",
     "oversizedMessage": "This file ({{size}}) exceeds 20 MB and diff is skipped to avoid blocking the system.",
     "oversizedBannerTitle": "Large files detected — review before committing",
-    "oversizedBannerHint": "Consider adding these files to .gitignore to avoid bloating the repository."
+    "oversizedBannerHint": "Consider adding these files to .gitignore to avoid bloating the repository.",
+    "timedOut": "Git operation timed out. The repository may contain very large files or the disk is slow. Try again later."
   },
   "session": {
     "connected": "Connected",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -197,7 +197,11 @@
       "new": "新",
       "deleted": "删",
       "renamed": "改名"
-    }
+    },
+    "oversized": "大文件",
+    "oversizedMessage": "该文件 ({{size}}) 超过 20 MB，已跳过 diff 以避免阻塞系统。",
+    "oversizedBannerTitle": "检测到大文件 — 提交前请检查",
+    "oversizedBannerHint": "建议将这些文件添加到 .gitignore，避免仓库体积膨胀。"
   },
   "session": {
     "connected": "已连接",

--- a/apps/frontend/src/i18n/zh.json
+++ b/apps/frontend/src/i18n/zh.json
@@ -201,7 +201,8 @@
     "oversized": "大文件",
     "oversizedMessage": "该文件 ({{size}}) 超过 20 MB，已跳过 diff 以避免阻塞系统。",
     "oversizedBannerTitle": "检测到大文件 — 提交前请检查",
-    "oversizedBannerHint": "建议将这些文件添加到 .gitignore，避免仓库体积膨胀。"
+    "oversizedBannerHint": "建议将这些文件添加到 .gitignore，避免仓库体积膨胀。",
+    "timedOut": "Git 操作超时。仓库可能包含非常大的文件或磁盘较慢，请稍后重试。"
   },
   "session": {
     "connected": "已连接",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -243,6 +243,10 @@ export interface IssueChangedFile {
   unstaged: boolean
   additions?: number
   deletions?: number
+  /** true when the file exceeds the large-file threshold (20 MB) */
+  oversized?: boolean
+  /** human-readable file size (only set when oversized) */
+  sizeDisplay?: string
 }
 
 export interface IssueChangesResponse {
@@ -261,6 +265,10 @@ export interface IssueFilePatchResponse {
   truncated: boolean
   type?: IssueChangedFile['type']
   status?: string
+  /** true when the file exceeds the large-file threshold */
+  oversized?: boolean
+  /** human-readable file size (only set when oversized) */
+  sizeDisplay?: string
 }
 
 export interface EngineAvailability {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -255,6 +255,8 @@ export interface IssueChangesResponse {
   files: IssueChangedFile[]
   additions: number
   deletions: number
+  /** true when git status timed out (e.g. very large repo or slow disk) */
+  timedOut?: boolean
 }
 
 export interface IssueFilePatchResponse {


### PR DESCRIPTION
## Summary

- Large files (>20 MB) in the working tree caused `git diff` to block indefinitely, freezing the SSE connection and the changes panel
- Added `checkOversized()` utility using `lstat` (symlink-safe) with a shared `LARGE_FILE_THRESHOLD` constant
- Files exceeding the threshold are flagged as `oversized` and skipped for all diff/read operations
- Added 15s timeout to git commands in the changes route (was previously unbounded)
- Frontend shows an amber warning banner listing oversized files with a hint to add them to `.gitignore`
- Individual file cards display a size badge and skip patch fetching entirely

## Changed files

- `apps/api/src/utils/changes.ts` — new `LARGE_FILE_THRESHOLD`, `formatFileSize()`, `checkOversized()`
- `apps/api/src/routes/issues/changes.ts` — timeout, oversized detection, skip diff/patch
- `apps/api/src/events/changes-summary.ts` — skip reading oversized untracked files
- `packages/shared/src/index.ts` — `oversized`/`sizeDisplay` fields on shared types
- `apps/frontend/src/components/issue-detail/DiffPanel.tsx` — `OversizedFilesBanner`, per-file badge
- `apps/frontend/src/i18n/{en,zh}.json` — i18n keys

## Test plan

- [ ] Place a file >20 MB in a project's working directory and open the changes panel
- [ ] Verify the amber banner appears listing the file with its size
- [ ] Verify opening the file card shows the skip message instead of loading diff
- [ ] Verify other (normal-sized) files still show diffs correctly
- [ ] Verify SSE connection remains stable when oversized files are present