### PR TITLE
feat: cron page — collapse logs/config, add pagination, enrich lastRun

### DIFF
--- a/apps/api/src/cron/serialize.ts
+++ b/apps/api/src/cron/serialize.ts
@@ -1,5 +1,16 @@
+import { desc, eq } from 'drizzle-orm'
+import { db } from '@/db'
 import type { cronJobs } from '@/db/schema'
+import { cronJobLogs } from '@/db/schema'
 import { getBaker } from './index'
+
+export interface LastRun {
+  status: string
+  startedAt: string
+  durationMs: number | null
+  result: string | null
+  error: string | null
+}
 
 export interface SerializedCronJob {
   id: string
@@ -10,6 +21,7 @@ export interface SerializedCronJob {
   enabled: boolean
   status: string
   nextExecution: string | null
+  lastRun: LastRun | null
   isDeleted: boolean
   createdAt: string
   updatedAt: string
@@ -35,6 +47,32 @@ export function serializeJob(row: typeof cronJobs.$inferSelect): SerializedCronJ
     taskConfig = { _raw: row.taskConfig }
   }
 
+  // Fetch latest log entry for lastRun
+  let lastRun: LastRun | null = null
+  const [latestLog] = db
+    .select({
+      status: cronJobLogs.status,
+      startedAt: cronJobLogs.startedAt,
+      durationMs: cronJobLogs.durationMs,
+      result: cronJobLogs.result,
+      error: cronJobLogs.error,
+    })
+    .from(cronJobLogs)
+    .where(eq(cronJobLogs.jobId, row.id))
+    .orderBy(desc(cronJobLogs.id))
+    .limit(1)
+    .all()
+
+  if (latestLog) {
+    lastRun = {
+      status: latestLog.status,
+      startedAt: latestLog.startedAt,
+      durationMs: latestLog.durationMs,
+      result: latestLog.result,
+      error: latestLog.error,
+    }
+  }
+
   return {
     id: row.id,
     name: row.name,
@@ -44,6 +82,7 @@ export function serializeJob(row: typeof cronJobs.$inferSelect): SerializedCronJ
     enabled: row.enabled,
     status,
     nextExecution,
+    lastRun,
     isDeleted: row.isDeleted === 1,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),

--- a/apps/api/src/routes/cron.ts
+++ b/apps/api/src/routes/cron.ts
@@ -8,20 +8,74 @@ import { serializeJob } from '@/cron/serialize'
 
 const cronRoute = new Hono()
 
+const jobsQuerySchema = z.object({
+  deleted: z.enum(['true', 'false', 'only']).optional(),
+  limit: z.coerce.number().min(1).max(100).optional(),
+  cursor: z.string().optional(),
+})
+
 const logsQuerySchema = z.object({
   status: z.enum(['success', 'failed', 'running']).optional(),
   limit: z.coerce.number().min(1).max(100).optional(),
   cursor: z.string().optional(),
 })
 
-// GET /api/cron — list all cron jobs (including soft-deleted)
-cronRoute.get('/', (c) => {
+// GET /api/cron — list cron jobs with optional pagination and deletion filter
+cronRoute.get('/', zValidator('query', jobsQuerySchema), (c) => {
+  const { deleted, limit, cursor } = c.req.valid('query')
+
+  // No pagination requested — return all (backward compatible)
+  if (!limit && !cursor) {
+    const rows = db
+      .select()
+      .from(cronJobs)
+      .orderBy(desc(cronJobs.createdAt))
+      .all()
+
+    const filtered = deleted === 'only'
+      ? rows.filter(r => r.isDeleted === 1)
+      : deleted === 'false'
+        ? rows.filter(r => r.isDeleted === 0)
+        : rows
+
+    return c.json({ success: true, data: filtered.map(serializeJob) })
+  }
+
+  // Paginated mode
+  const pageLimit = limit ?? 20
+  const conditions: ReturnType<typeof eq>[] = []
+
+  if (deleted === 'only') {
+    conditions.push(eq(cronJobs.isDeleted, 1))
+  } else if (deleted === 'false' || !deleted) {
+    conditions.push(eq(cronJobs.isDeleted, 0))
+  }
+  // deleted === 'true' means include all, no filter
+
+  if (cursor) {
+    conditions.push(lt(cronJobs.id, cursor))
+  }
+
   const rows = db
     .select()
     .from(cronJobs)
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .orderBy(desc(cronJobs.createdAt))
+    .limit(pageLimit + 1)
     .all()
 
-  return c.json({ success: true, data: rows.map(serializeJob) })
+  const hasMore = rows.length > pageLimit
+  const page = hasMore ? rows.slice(0, pageLimit) : rows
+  const nextCursor = hasMore ? page.at(-1)!.id : null
+
+  return c.json({
+    success: true,
+    data: {
+      jobs: page.map(serializeJob),
+      hasMore,
+      nextCursor,
+    },
+  })
 })
 
 // GET /api/cron/:jobId/logs — get logs for a specific job

--- a/apps/frontend/src/components/issue-detail/ToolItems.tsx
+++ b/apps/frontend/src/components/issue-detail/ToolItems.tsx
@@ -497,7 +497,7 @@ const MemoizedToolItemRenderer = memo(ToolItemRenderer)
 
 export function ToolGroupMessage({ message }: { message: ToolGroupChatMessage }) {
   const { t } = useTranslation()
-  const { items, stats, count, description } = message
+  const { items, stats, count, description, isActive } = message
   const statsLabel = getGroupSummaryLabel(stats, count, t)
   const bodyId = `tg-body-${message.id}`
 
@@ -506,45 +506,39 @@ export function ToolGroupMessage({ message }: { message: ToolGroupChatMessage })
   const [isOpen, setIsOpen] = useState(true)
   const [expanded, setExpanded] = useState(false)
 
-  // Group is actively streaming when the last tool call has no result yet.
-  // Completed groups always have all results paired via resultMap in useChatMessages.
-  const isStreaming = items.length > 0 && items.at(-1)?.result === null
+  // isActive is set by useChatMessages — true when this group is the trailing
+  // tool group (no subsequent assistant/user message has flushed it yet).
+  // It stays true until the next conversation message arrives, so it won't
+  // flicker between tool action/result pairs.
+  const isActiveRef = useRef(isActive)
+  isActiveRef.current = isActive
 
-  // Ref for click handler to avoid stale-closure on streaming→completed boundary.
-  const isStreamingRef = useRef(isStreaming)
-  isStreamingRef.current = isStreaming
+  // Track whether this group was ever active (streaming).
+  // Historical groups skip the auto-collapse on mount.
+  const wasEverActiveRef = useRef(!!isActive)
+  if (isActive) wasEverActiveRef.current = true
 
-  // Track whether this group was ever in streaming state.
-  // Historical (already completed) groups skip the auto-collapse on mount.
-  const wasEverStreamingRef = useRef(isStreaming)
-  if (isStreaming) wasEverStreamingRef.current = true
-
-  // When streaming ends, reset expanded so items truncate back to DEFAULT_VISIBLE_COUNT.
-  // Body stays open (isOpen remains true) — only item truncation resets.
+  // When the group is no longer active (assistant message arrived),
+  // reset expanded so items truncate back to DEFAULT_VISIBLE_COUNT.
   useEffect(() => {
-    if (!isStreaming && wasEverStreamingRef.current) {
-      const timer = setTimeout(() => {
-        if (!isStreamingRef.current) {
-          setExpanded(false)
-        }
-      }, 500)
-      return () => clearTimeout(timer)
+    if (!isActive && wasEverActiveRef.current) {
+      setExpanded(false)
     }
-  }, [isStreaming])
+  }, [isActive])
 
   // During streaming: always show body (auto-expand)
   // After streaming: user controls via isOpen
-  const bodyVisible = isStreaming || isOpen
+  const bodyVisible = isActive || isOpen
 
   const hasMore = items.length > DEFAULT_VISIBLE_COUNT
-  // No truncation during streaming (show all items in real-time)
-  const shouldTruncate = bodyVisible && hasMore && !expanded && !isStreaming
+  // No truncation while group is active (show all items in real-time)
+  const shouldTruncate = bodyVisible && hasMore && !expanded && !isActive
   const visibleItems = shouldTruncate ? items.slice(0, DEFAULT_VISIBLE_COUNT) : items
   const truncatedCount = items.length - DEFAULT_VISIBLE_COUNT
 
   const handleHeaderClick = useCallback(() => {
     // During streaming, body is auto-expanded — header click is a no-op
-    if (!isStreamingRef.current) {
+    if (!isActiveRef.current) {
       setIsOpen(v => !v)
     }
   }, [])
@@ -557,7 +551,7 @@ export function ToolGroupMessage({ message }: { message: ToolGroupChatMessage })
           onClick={handleHeaderClick}
           aria-expanded={bodyVisible}
           aria-controls={bodyId}
-          aria-disabled={isStreaming || undefined}
+          aria-disabled={isActive || undefined}
           className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground cursor-pointer select-none bg-muted/60"
         >
           <ChevronRight className={`h-3 w-3 shrink-0 transition-transform ${bodyVisible ? 'rotate-90' : ''}`} />
@@ -587,7 +581,7 @@ export function ToolGroupMessage({ message }: { message: ToolGroupChatMessage })
                       </button>
                     )
                   : null}
-                {hasMore && expanded && !isStreaming
+                {hasMore && expanded && !isActive
                   ? (
                       <button
                         type="button"

--- a/apps/frontend/src/hooks/use-chat-messages.ts
+++ b/apps/frontend/src/hooks/use-chat-messages.ts
@@ -345,6 +345,21 @@ function rebuildMessages(entries: NormalizedLogEntry[]): ChatMessage[] {
 
   flushToolBuffer()
   flushPendingThinking()
+
+  // Mark the trailing tool group as active — it hasn't been closed by a
+  // subsequent assistant/user message, so it may still receive new tool calls.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].type === 'tool-group') {
+      (messages[i] as ToolGroupChatMessage).isActive = true
+      break
+    }
+    // Stop searching if an assistant message is found — the group was
+    // properly flushed and is no longer the trailing group.
+    // Note: user messages include pending/done types that don't flush tool
+    // buffers, so only assistant messages are a reliable boundary.
+    if (messages[i].type === 'assistant') break
+  }
+
   return messages
 }
 

--- a/apps/frontend/src/hooks/use-kanban.ts
+++ b/apps/frontend/src/hooks/use-kanban.ts
@@ -979,10 +979,10 @@ export function useCronJobs() {
   })
 }
 
-export function useCronJobLogs(jobId: string | null) {
+export function useCronJobLogs(jobId: string | null, opts?: { limit?: number }) {
   return useQuery({
     queryKey: queryKeys.cronJobLogs(jobId ?? ''),
-    queryFn: () => kanbanApi.getCronJobLogs(jobId!),
+    queryFn: () => kanbanApi.getCronJobLogs(jobId!, { limit: opts?.limit }),
     enabled: !!jobId,
     staleTime: STALE_TIME.STANDARD,
   })

--- a/apps/frontend/src/pages/CronPage.tsx
+++ b/apps/frontend/src/pages/CronPage.tsx
@@ -18,7 +18,7 @@ import { Link } from 'react-router-dom'
 import { AppLogo } from '@/components/AppLogo'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { useCronJobs } from '@/hooks/use-kanban'
 import type { CronJob, CronJobLog, CronJobLogsResponse } from '@/lib/kanban-api'
 import { kanbanApi } from '@/lib/kanban-api'
@@ -97,7 +97,7 @@ function CronJobList({
   }
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
       {jobs.map((job, index) => (
         <div
           key={job.id}
@@ -108,58 +108,43 @@ function CronJobList({
             className={`h-full cursor-pointer transition-all hover:shadow-md group ${isDeletedView ? 'bg-card/40 opacity-70 hover:opacity-100 hover:bg-card/60' : 'bg-card/70 hover:bg-card hover:border-primary/20'}`}
             onClick={() => onSelectJob(job)}
           >
-            <CardHeader className="pb-2">
-              <div className="flex items-start justify-between gap-2">
+            <CardContent className="py-3 px-4">
+              <div className="flex items-start justify-between gap-2 mb-2">
                 <div className="min-w-0 flex-1">
-                  <CardTitle className={`text-base transition-colors truncate ${isDeletedView ? 'line-through text-muted-foreground group-hover:text-foreground' : 'group-hover:text-primary'}`}>
+                  <p className={`text-sm font-medium transition-colors truncate ${isDeletedView ? 'line-through text-muted-foreground group-hover:text-foreground' : 'group-hover:text-primary'}`}>
                     {job.name}
-                  </CardTitle>
-                  <p className="mt-0.5 text-xs text-muted-foreground font-mono">
+                  </p>
+                  <p className="text-[11px] text-muted-foreground font-mono">
                     {job.cron}
                   </p>
                 </div>
                 {isDeletedView
                   ? (
-                      <Badge variant="secondary" className="bg-muted text-muted-foreground">
-                        <Trash2 className="mr-1 h-3 w-3" />
+                      <Badge variant="secondary" className="bg-muted text-muted-foreground text-[10px]">
+                        <Trash2 className="mr-0.5 h-2.5 w-2.5" />
                         {t('cron.deleted')}
                       </Badge>
                     )
                   : <StatusBadge status={job.enabled ? job.status : 'disabled'} />}
               </div>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-1.5 text-xs text-muted-foreground">
+              <div className="space-y-1 text-[11px] text-muted-foreground">
                 {!isDeletedView && (
-                  <div className="flex items-center gap-1.5">
-                    <Clock className="h-3 w-3 shrink-0" />
-                    <span>
-                      {t('cron.nextExecution')}
-                      :
-                    </span>
+                  <div className="flex items-center gap-1">
+                    <Clock className="h-2.5 w-2.5 shrink-0" />
                     <span className="ml-auto font-mono truncate">
                       {job.nextExecution ? formatTime(job.nextExecution) : '-'}
                     </span>
                   </div>
                 )}
                 {job.lastRun && (
-                  <div className="flex items-center gap-1.5">
-                    <Timer className="h-3 w-3 shrink-0" />
-                    <span>
-                      {t('cron.lastRun')}
-                      :
-                    </span>
-                    <span className="ml-auto flex items-center gap-1.5">
+                  <div className="flex items-center gap-1">
+                    <Timer className="h-2.5 w-2.5 shrink-0" />
+                    <span className="ml-auto flex items-center gap-1">
                       <StatusBadge status={job.lastRun.status} />
                       <span className="font-mono">{formatDuration(job.lastRun.durationMs)}</span>
                     </span>
                   </div>
                 )}
-                <div className="flex items-center gap-1.5">
-                  <Badge variant="outline" className="text-[10px] px-1 py-0">
-                    {job.taskType}
-                  </Badge>
-                </div>
               </div>
             </CardContent>
           </Card>
@@ -180,28 +165,24 @@ function TaskConfigView({ config }: { config: Record<string, unknown> }) {
   const jsonStr = JSON.stringify(config, null, 2)
 
   return (
-    <div className="mt-4 mb-6">
+    <div className="mt-3 mb-4">
       <button
         type="button"
         onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-1.5 text-sm font-medium hover:text-foreground transition-colors mb-2"
+        className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors mb-1.5"
       >
-        <ChevronRight className={`h-3.5 w-3.5 text-muted-foreground transition-transform ${expanded ? 'rotate-90' : ''}`} />
+        <ChevronRight className={`h-3 w-3 transition-transform ${expanded ? 'rotate-90' : ''}`} />
         {t('cron.taskConfig')}
-        <Badge variant="secondary" className="ml-1 text-[10px]">
+        <span className="text-[10px] opacity-60">
+          (
           {entries.length}
-          {' '}
-          {entries.length === 1 ? 'key' : 'keys'}
-        </Badge>
+          )
+        </span>
       </button>
       {expanded && (
-        <Card className="bg-muted/30">
-          <CardContent className="py-3 px-4">
-            <pre className="text-xs font-mono text-foreground whitespace-pre-wrap break-all">
-              {jsonStr}
-            </pre>
-          </CardContent>
-        </Card>
+        <pre className="text-[11px] font-mono text-foreground/80 whitespace-pre-wrap break-all bg-muted/30 rounded px-3 py-2">
+          {jsonStr}
+        </pre>
       )}
     </div>
   )
@@ -257,27 +238,27 @@ function CronJobLogView({ job, onBack }: { job: CronJob, onBack: () => void }) {
       <button
         type="button"
         onClick={onBack}
-        className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3"
       >
-        <ArrowLeft className="h-4 w-4" />
+        <ArrowLeft className="h-3.5 w-3.5" />
         {t('cron.backToJobs')}
       </button>
 
-      <div className="mb-4">
+      <div className="mb-3">
         <div className="flex items-center gap-2">
-          <h2 className="text-lg font-semibold">{job.name}</h2>
+          <h2 className="text-base font-semibold">{job.name}</h2>
           {job.isDeleted && (
-            <Badge variant="secondary" className="bg-muted text-muted-foreground">
-              <Trash2 className="mr-1 h-3 w-3" />
+            <Badge variant="secondary" className="bg-muted text-muted-foreground text-[10px]">
+              <Trash2 className="mr-0.5 h-2.5 w-2.5" />
               {t('cron.deleted')}
             </Badge>
           )}
         </div>
-        <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground">
+        <div className="flex items-center gap-2 mt-0.5 text-xs text-muted-foreground">
           <span className="font-mono">{job.cron}</span>
           {!job.isDeleted && <StatusBadge status={job.enabled ? job.status : 'disabled'} />}
           {job.nextExecution && !job.isDeleted && (
-            <span className="text-xs">
+            <span className="text-[11px]">
               {t('cron.nextExecution')}
               :
               {' '}
@@ -289,41 +270,41 @@ function CronJobLogView({ job, onBack }: { job: CronJob, onBack: () => void }) {
 
       <TaskConfigView config={job.taskConfig} />
 
-      <h3 className="text-sm font-medium mb-3">
+      <h3 className="text-xs font-medium text-muted-foreground mb-2">
         {t('cron.logs')}
         {logs.length > 0 && (
-          <Badge variant="secondary" className="ml-2 text-xs">
+          <span className="ml-1.5 opacity-60">
             {logs.length}
             {hasMore ? '+' : ''}
-          </Badge>
+          </span>
         )}
       </h3>
 
       {isLoading ? (
-        <div className="flex items-center justify-center py-8">
-          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <div className="flex items-center justify-center py-6">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
         </div>
       ) : logs.length === 0 ? (
-        <div className="text-center py-8 text-muted-foreground">
+        <div className="text-center py-6 text-muted-foreground text-xs">
           <p>{t('cron.noLogs')}</p>
         </div>
       ) : (
-        <div className="space-y-2">
+        <div className="space-y-1.5">
           {logs.map((log: CronJobLog) => (
             <LogEntry key={log.id} log={log} />
           ))}
           {hasMore && (
-            <div className="flex justify-center pt-2">
+            <div className="flex justify-center pt-1">
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={loadMore}
                 disabled={isLoadingMore}
-                className="text-muted-foreground"
+                className="text-muted-foreground h-7 text-xs"
               >
                 {isLoadingMore
-                  ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                  : <ChevronDown className="mr-1.5 h-3.5 w-3.5" />}
+                  ? <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                  : <ChevronDown className="mr-1 h-3 w-3" />}
                 {t('cron.loadMore')}
               </Button>
             </div>
@@ -337,13 +318,12 @@ function CronJobLogView({ job, onBack }: { job: CronJob, onBack: () => void }) {
 /* -- Single log entry (collapsed by default) -------------- */
 
 function LogEntry({ log }: { log: CronJobLog }) {
-  const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const hasDetail = !!(log.result || log.error)
 
   return (
-    <Card
-      className={`bg-card/50 ${hasDetail ? 'cursor-pointer' : ''}`}
+    <div
+      className={`rounded-md border bg-card/50 px-3 py-2 ${hasDetail ? 'cursor-pointer hover:bg-card/70' : ''}`}
       onClick={() => hasDetail && setExpanded(!expanded)}
       onKeyDown={hasDetail
         ? (e) => {
@@ -357,53 +337,42 @@ function LogEntry({ log }: { log: CronJobLog }) {
       role={hasDetail ? 'button' : undefined}
       aria-expanded={hasDetail ? expanded : undefined}
     >
-      <CardContent className="py-3 px-4">
-        <div className="flex items-center gap-3">
-          <StatusBadge status={log.status} />
-          <span className="text-xs text-muted-foreground font-mono">
-            {formatTime(log.startedAt)}
+      <div className="flex items-center gap-2">
+        <StatusBadge status={log.status} />
+        <span className="text-[11px] text-muted-foreground font-mono">
+          {formatTime(log.startedAt)}
+        </span>
+        {log.durationMs !== null && (
+          <span className="text-[11px] text-muted-foreground font-mono">
+            {formatDuration(log.durationMs)}
           </span>
-          {log.durationMs !== null && (
-            <span className="text-xs text-muted-foreground">
-              {t('cron.duration')}
-              :
-              {' '}
-              {formatDuration(log.durationMs)}
-            </span>
+        )}
+        {hasDetail && (
+          <ChevronRight className={`ml-auto h-3 w-3 text-muted-foreground/50 transition-transform ${expanded ? 'rotate-90' : ''}`} />
+        )}
+      </div>
+      {expanded && (
+        <div className="mt-2 space-y-1.5">
+          {log.result && (
+            <pre className="text-[11px] font-mono text-foreground/80 whitespace-pre-wrap break-all bg-muted/30 rounded px-2 py-1.5">
+              {log.result}
+            </pre>
           )}
-          {hasDetail && (
-            <ChevronRight className={`ml-auto h-3.5 w-3.5 text-muted-foreground transition-transform ${expanded ? 'rotate-90' : ''}`} />
+          {log.error && (
+            <pre className="text-[11px] font-mono text-red-500 whitespace-pre-wrap break-all bg-red-500/5 rounded px-2 py-1.5">
+              {log.error}
+            </pre>
+          )}
+          {log.finishedAt && (
+            <p className="text-[10px] text-muted-foreground/60">
+              {formatTime(log.startedAt)}
+              {' → '}
+              {formatTime(log.finishedAt)}
+            </p>
           )}
         </div>
-        {expanded && (
-          <div className="mt-3 space-y-2">
-            {log.result && (
-              <div>
-                <p className="text-[10px] font-medium text-muted-foreground mb-1">{t('cron.result')}</p>
-                <pre className="text-xs font-mono text-foreground whitespace-pre-wrap break-all bg-muted/40 rounded px-2.5 py-2">
-                  {log.result}
-                </pre>
-              </div>
-            )}
-            {log.error && (
-              <div>
-                <p className="text-[10px] font-medium text-red-500 mb-1">{t('cron.error')}</p>
-                <pre className="text-xs font-mono text-red-500 whitespace-pre-wrap break-all bg-red-500/5 rounded px-2.5 py-2">
-                  {log.error}
-                </pre>
-              </div>
-            )}
-            {log.finishedAt && (
-              <p className="text-[10px] text-muted-foreground">
-                {formatTime(log.startedAt)}
-                {' → '}
-                {formatTime(log.finishedAt)}
-              </p>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+      )}
+    </div>
   )
 }
 
@@ -420,13 +389,13 @@ export default function CronPage() {
 
   return (
     <main className="min-h-screen text-foreground animate-page-enter">
-      <section className="mx-auto max-w-6xl px-4 py-6 md:px-6 md:py-12">
+      <section className="mx-auto max-w-6xl px-4 py-4 md:px-6 md:py-8">
         {/* Header */}
-        <div className="mb-6 flex items-center gap-3 md:mb-8">
+        <div className="mb-4 flex items-center gap-2.5 md:mb-6">
           <Link to="/" aria-label={t('sidebar.home')}>
-            <AppLogo className="h-9 w-9" />
+            <AppLogo className="h-8 w-8" />
           </Link>
-          <h1 className="text-xl font-semibold tracking-tight md:text-2xl">
+          <h1 className="text-lg font-semibold tracking-tight md:text-xl">
             {t('cron.title')}
           </h1>
           {jobs && (
@@ -464,21 +433,13 @@ export default function CronPage() {
 
         {/* Content */}
         {isLoading ? (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 3 }).map((_, i) => (
-              <Card key={i} className="bg-card/30 animate-pulse min-h-[120px]">
-                <CardHeader>
-                  <div className="flex items-start gap-3">
-                    <div className="flex-1 space-y-2">
-                      <div className="h-4 w-24 rounded bg-muted" />
-                      <div className="h-3 w-32 rounded bg-muted" />
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <div className="h-3 w-40 rounded bg-muted" />
-                </CardContent>
-              </Card>
+              <div key={i} className="rounded-lg border bg-card/30 animate-pulse p-4 space-y-2">
+                <div className="h-3.5 w-24 rounded bg-muted" />
+                <div className="h-3 w-32 rounded bg-muted" />
+                <div className="h-3 w-40 rounded bg-muted mt-3" />
+              </div>
             ))}
           </div>
         ) : selectedJob ? (
@@ -494,18 +455,20 @@ export default function CronPage() {
               onSelectJob={setSelectedJob}
             />
             {deletedJobs.length > 0 && (
-              <div className="mt-8">
+              <div className="mt-6">
                 <button
                   type="button"
                   onClick={() => setShowDeleted(!showDeleted)}
-                  className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3"
                 >
-                  <ChevronRight className={`h-4 w-4 transition-transform ${showDeleted ? 'rotate-90' : ''}`} />
-                  <Trash2 className="h-3.5 w-3.5" />
+                  <ChevronRight className={`h-3.5 w-3.5 transition-transform ${showDeleted ? 'rotate-90' : ''}`} />
+                  <Trash2 className="h-3 w-3" />
                   {t('cron.deletedJobs')}
-                  <Badge variant="secondary" className="ml-1 text-xs">
+                  <span className="ml-1 opacity-60">
+                    (
                     {deletedJobs.length}
-                  </Badge>
+                    )
+                  </span>
                 </button>
                 {showDeleted && (
                   <CronJobList

--- a/apps/frontend/src/pages/CronPage.tsx
+++ b/apps/frontend/src/pages/CronPage.tsx
@@ -2,6 +2,7 @@ import {
   ArrowLeft,
   Calendar,
   CheckCircle2,
+  ChevronDown,
   ChevronRight,
   Clock,
   Loader2,
@@ -11,17 +12,20 @@ import {
   Trash2,
   XCircle,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { AppLogo } from '@/components/AppLogo'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { useCronJobLogs, useCronJobs } from '@/hooks/use-kanban'
-import type { CronJob, CronJobLog } from '@/lib/kanban-api'
+import { useCronJobs } from '@/hooks/use-kanban'
+import type { CronJob, CronJobLog, CronJobLogsResponse } from '@/lib/kanban-api'
+import { kanbanApi } from '@/lib/kanban-api'
 import { useNotesStore } from '@/stores/notes-store'
 import { useTerminalStore } from '@/stores/terminal-store'
+
+const LOG_PAGE_SIZE = 20
 
 function formatDuration(ms: number | null): string {
   if (ms === null) return '-'
@@ -165,40 +169,88 @@ function CronJobList({
   )
 }
 
-/* -- Log list view ---------------------------------------- */
+/* -- Task config as collapsible JSON ---------------------- */
 
 function TaskConfigView({ config }: { config: Record<string, unknown> }) {
   const { t } = useTranslation()
+  const [expanded, setExpanded] = useState(false)
   const entries = Object.entries(config)
   if (entries.length === 0) return null
 
+  const jsonStr = JSON.stringify(config, null, 2)
+
   return (
     <div className="mt-4 mb-6">
-      <h3 className="text-sm font-medium mb-2">{t('cron.taskConfig')}</h3>
-      <Card className="bg-muted/30">
-        <CardContent className="py-3 px-4">
-          <div className="space-y-1.5">
-            {entries.map(([key, value]) => (
-              <div key={key} className="flex items-start gap-2 text-xs">
-                <span className="font-mono text-muted-foreground shrink-0">
-                  {key}
-                  :
-                </span>
-                <span className="font-mono break-all">
-                  {typeof value === 'object' ? JSON.stringify(value) : String(value)}
-                </span>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-1.5 text-sm font-medium hover:text-foreground transition-colors mb-2"
+      >
+        <ChevronRight className={`h-3.5 w-3.5 text-muted-foreground transition-transform ${expanded ? 'rotate-90' : ''}`} />
+        {t('cron.taskConfig')}
+        <Badge variant="secondary" className="ml-1 text-[10px]">
+          {entries.length}
+          {' '}
+          {entries.length === 1 ? 'key' : 'keys'}
+        </Badge>
+      </button>
+      {expanded && (
+        <Card className="bg-muted/30">
+          <CardContent className="py-3 px-4">
+            <pre className="text-xs font-mono text-foreground whitespace-pre-wrap break-all">
+              {jsonStr}
+            </pre>
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }
 
+/* -- Log detail view with pagination ---------------------- */
+
 function CronJobLogView({ job, onBack }: { job: CronJob, onBack: () => void }) {
   const { t } = useTranslation()
-  const { data, isLoading } = useCronJobLogs(job.id)
+  const [logs, setLogs] = useState<CronJobLog[]>([])
+  const [hasMore, setHasMore] = useState(false)
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+
+  const fetchLogs = useCallback(async (cursor?: string) => {
+    const data = await kanbanApi.getCronJobLogs(job.id, {
+      limit: LOG_PAGE_SIZE,
+      cursor,
+    }) as CronJobLogsResponse
+    return data
+  }, [job.id])
+
+  // Initial load
+  const [initialized, setInitialized] = useState(false)
+  if (!initialized) {
+    setInitialized(true)
+    fetchLogs().then((data) => {
+      setLogs(data.logs)
+      setHasMore(data.hasMore)
+      setNextCursor(data.nextCursor)
+      setIsLoading(false)
+    }).catch(() => {
+      setIsLoading(false)
+    })
+  }
+
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || isLoadingMore) return
+    setIsLoadingMore(true)
+    try {
+      const data = await fetchLogs(nextCursor)
+      setLogs(prev => [...prev, ...data.logs])
+      setHasMore(data.hasMore)
+      setNextCursor(data.nextCursor)
+    } finally {
+      setIsLoadingMore(false)
+    }
+  }, [nextCursor, isLoadingMore, fetchLogs])
 
   return (
     <div>
@@ -228,6 +280,7 @@ function CronJobLogView({ job, onBack }: { job: CronJob, onBack: () => void }) {
             <span className="text-xs">
               {t('cron.nextExecution')}
               :
+              {' '}
               {formatTime(job.nextExecution)}
             </span>
           )}
@@ -236,26 +289,52 @@ function CronJobLogView({ job, onBack }: { job: CronJob, onBack: () => void }) {
 
       <TaskConfigView config={job.taskConfig} />
 
-      <h3 className="text-sm font-medium mb-3">{t('cron.logs')}</h3>
+      <h3 className="text-sm font-medium mb-3">
+        {t('cron.logs')}
+        {logs.length > 0 && (
+          <Badge variant="secondary" className="ml-2 text-xs">
+            {logs.length}
+            {hasMore ? '+' : ''}
+          </Badge>
+        )}
+      </h3>
 
       {isLoading ? (
         <div className="flex items-center justify-center py-8">
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
-      ) : !data?.logs.length ? (
+      ) : logs.length === 0 ? (
         <div className="text-center py-8 text-muted-foreground">
           <p>{t('cron.noLogs')}</p>
         </div>
       ) : (
         <div className="space-y-2">
-          {data.logs.map((log: CronJobLog) => (
+          {logs.map((log: CronJobLog) => (
             <LogEntry key={log.id} log={log} />
           ))}
+          {hasMore && (
+            <div className="flex justify-center pt-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={loadMore}
+                disabled={isLoadingMore}
+                className="text-muted-foreground"
+              >
+                {isLoadingMore
+                  ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  : <ChevronDown className="mr-1.5 h-3.5 w-3.5" />}
+                {t('cron.loadMore')}
+              </Button>
+            </div>
+          )}
         </div>
       )}
     </div>
   )
 }
+
+/* -- Single log entry (collapsed by default) -------------- */
 
 function LogEntry({ log }: { log: CronJobLog }) {
   const { t } = useTranslation()
@@ -284,17 +363,11 @@ function LogEntry({ log }: { log: CronJobLog }) {
           <span className="text-xs text-muted-foreground font-mono">
             {formatTime(log.startedAt)}
           </span>
-          {log.finishedAt && (
-            <span className="text-xs text-muted-foreground">
-              →
-              {' '}
-              {formatTime(log.finishedAt)}
-            </span>
-          )}
           {log.durationMs !== null && (
             <span className="text-xs text-muted-foreground">
               {t('cron.duration')}
               :
+              {' '}
               {formatDuration(log.durationMs)}
             </span>
           )}
@@ -302,16 +375,6 @@ function LogEntry({ log }: { log: CronJobLog }) {
             <ChevronRight className={`ml-auto h-3.5 w-3.5 text-muted-foreground transition-transform ${expanded ? 'rotate-90' : ''}`} />
           )}
         </div>
-        {!expanded && log.result && (
-          <p className="mt-1.5 text-xs text-muted-foreground font-mono truncate">
-            {log.result}
-          </p>
-        )}
-        {!expanded && log.error && (
-          <p className="mt-1.5 text-xs text-red-500 font-mono truncate">
-            {log.error}
-          </p>
-        )}
         {expanded && (
           <div className="mt-3 space-y-2">
             {log.result && (
@@ -329,6 +392,13 @@ function LogEntry({ log }: { log: CronJobLog }) {
                   {log.error}
                 </pre>
               </div>
+            )}
+            {log.finishedAt && (
+              <p className="text-[10px] text-muted-foreground">
+                {formatTime(log.startedAt)}
+                {' → '}
+                {formatTime(log.finishedAt)}
+              </p>
             )}
           </div>
         )}
@@ -413,6 +483,7 @@ export default function CronPage() {
           </div>
         ) : selectedJob ? (
           <CronJobLogView
+            key={selectedJob.id}
             job={selectedJob}
             onBack={() => setSelectedJob(null)}
           />

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -151,6 +151,8 @@ export interface ToolGroupChatMessage {
   hiddenCount: number
   /** Thinking/description text absorbed from the preceding thinking entry */
   description?: string
+  /** True when this group is the last in the message list and may still receive new tool calls */
+  isActive?: boolean
 }
 
 export interface TaskPlanChatMessage {


### PR DESCRIPTION
## Summary

- **Backend `lastRun` enrichment**: `serializeJob()` now fetches the latest log entry per job, populating the `lastRun` field that the frontend expects
- **Backend pagination support**: `GET /api/cron` now accepts optional `limit`, `cursor`, and `deleted` (true/false/only) query params; backward compatible when omitted
- **Task config as collapsible JSON**: Replaced key-value pair display with raw JSON in a collapsible section — easier to inspect complex payloads
- **Logs collapsed by default**: Log entries show only status + timestamp + duration; click to expand full result/error + time range
- **Log pagination**: Cursor-based "Load more" button in log detail view (20 per page)
- **Log count badge**: Shows total loaded count next to heading

## Test plan

- [ ] Open `/cron` — verify job cards show `lastRun` status and duration
- [ ] Click a job — verify task config section is collapsed; click to expand and see raw JSON
- [ ] Verify log entries are collapsed by default (no truncated preview)
- [ ] Click a log entry with result/error — verify it expands to show full content
- [ ] If a job has >20 logs, verify "Load more" button appears and loads next page
- [ ] Soft-delete a job — verify it appears in collapsed "Deleted Jobs" section
- [ ] Click deleted job — verify logs are still accessible with pagination
- [ ] API: `GET /api/cron?deleted=only&limit=5` — verify paginated response