### PR TITLE
feat: enable auto mode and align normalizer with SDK v0.80.0

### DIFF
--- a/apps/api/src/engines/executors/claude/executor.ts
+++ b/apps/api/src/engines/executors/claude/executor.ts
@@ -376,10 +376,13 @@ export class ClaudeCodeExecutor implements EngineExecutor {
       }
     }
 
-    // Plan mode: start CLI with bypassPermissions so we can switch back to it
-    // after ExitPlanMode. SDK protocol then sets the actual mode to "plan".
+    // Set CLI-level permission mode:
+    // - plan: bootstrap with bypassPermissions so SDK can switch back after ExitPlanMode
+    // - auto: enable the built-in AI classifier; stdio protocol acts as fallback approver
     if (isPlanMode) {
       builder.param('--permission-mode', 'bypassPermissions')
+    } else {
+      builder.param('--permission-mode', 'auto')
     }
 
     if (options.model && options.model !== 'auto') {

--- a/apps/api/src/engines/executors/claude/normalizer-tool.ts
+++ b/apps/api/src/engines/executors/claude/normalizer-tool.ts
@@ -28,14 +28,16 @@ export function generateToolContent(toolName: string, input: Record<string, unkn
     case 'Grep':
       return input.path ? `${input.pattern} in ${input.path}` : String(input.pattern ?? toolName)
     case 'Glob':
-      return input.path ?
-        `${input.pattern ?? input.filePattern} in ${input.path}` :
-          String(input.pattern ?? input.filePattern ?? toolName)
+      return input.path
+        ? `${input.pattern ?? input.filePattern} in ${input.path}`
+        : String(input.pattern ?? input.filePattern ?? toolName)
     case 'LS':
       return String(input.path ?? toolName)
     case 'WebFetch':
+    case 'web_fetch':
       return String(input.url ?? toolName)
     case 'WebSearch':
+    case 'web_search':
       return String(input.query ?? toolName)
     case 'Task':
       return input.description ? `Task: ${input.description}` : 'Task'
@@ -47,6 +49,15 @@ export function generateToolContent(toolName: string, input: Record<string, unkn
       return String(input.plan ?? 'Plan submitted')
     case 'NotebookEdit':
       return String(input.notebook_path ?? toolName)
+    // Server-side tools
+    case 'code_execution':
+    case 'bash_code_execution':
+      return String(input.code ?? input.command ?? `Server: ${toolName}`)
+    case 'text_editor_code_execution':
+      return String(input.command ?? `Server: ${toolName}`)
+    case 'tool_search_tool_regex':
+    case 'tool_search_tool_bm25':
+      return String(input.query ?? `Server: ${toolName}`)
     default: {
       // MCP tools: mcp__server__tool → mcp:server:tool
       if (toolName.startsWith('mcp__')) {
@@ -75,9 +86,20 @@ export function classifyToolKind(toolName: string): string {
     case 'Glob':
       return 'search'
     case 'WebFetch':
+    case 'web_fetch':
       return 'web-fetch'
+    case 'WebSearch':
+    case 'web_search':
+      return 'search'
     case 'Task':
       return 'task'
+    case 'code_execution':
+    case 'bash_code_execution':
+    case 'text_editor_code_execution':
+      return 'command-run'
+    case 'tool_search_tool_regex':
+    case 'tool_search_tool_bm25':
+      return 'search'
     default:
       return 'tool'
   }
@@ -99,19 +121,33 @@ export function classifyToolAction(toolName: string, input: Record<string, unkno
         path: String(input.file_path ?? input.path ?? ''),
       }
     case 'Bash':
+    case 'code_execution':
+    case 'bash_code_execution':
       return {
         kind: 'command-run',
-        command: String(input.command ?? input.cmd ?? ''),
-        category: classifyCommand(String(input.command ?? input.cmd ?? '')) as CommandCategory,
+        command: String(input.command ?? input.code ?? input.cmd ?? ''),
+        category: classifyCommand(String(input.command ?? input.code ?? input.cmd ?? '')) as CommandCategory,
+      }
+    case 'text_editor_code_execution':
+      return {
+        kind: 'command-run',
+        command: String(input.command ?? ''),
+        category: 'edit' as CommandCategory,
       }
     case 'Grep':
     case 'Glob':
+    case 'tool_search_tool_regex':
+    case 'tool_search_tool_bm25':
       return {
         kind: 'search',
         query: String(input.pattern ?? input.query ?? input.filePattern ?? ''),
       }
     case 'WebFetch':
+    case 'web_fetch':
       return { kind: 'web-fetch', url: String(input.url ?? '') }
+    case 'WebSearch':
+    case 'web_search':
+      return { kind: 'search', query: String(input.query ?? '') }
     default:
       return { kind: 'tool', toolName, arguments: input }
   }

--- a/apps/api/src/engines/executors/claude/normalizer-types.ts
+++ b/apps/api/src/engines/executors/claude/normalizer-types.ts
@@ -88,6 +88,8 @@ export interface ClaudeStreamEvent {
     type?: string
     text?: string
     thinking?: string
+    signature?: string
+    citation?: unknown
   }
   content_block?: ClaudeContentItem
   message?: ClaudeMessage
@@ -146,12 +148,13 @@ export interface ClaudeMessage {
   role?: string
   model?: string
   content?: ClaudeContentItem[] | string
-  stop_reason?: string
+  stop_reason?: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use' | 'pause_turn' | 'refusal' | string
 }
 
 export type ClaudeContentItem =
-  | { type: 'text', text: string } |
+  | { type: 'text', text: string, citations?: unknown[] | null } |
   { type: 'thinking', thinking: string } |
+  { type: 'redacted_thinking', data: string } |
   {
     type: 'tool_use'
     id?: string
@@ -163,6 +166,47 @@ export type ClaudeContentItem =
     tool_use_id?: string
     content?: string | unknown[]
     is_error?: boolean
+  } |
+  {
+    type: 'server_tool_use'
+    id: string
+    name: string
+    input?: unknown
+    caller?: { type: string, tool_id?: string }
+  } |
+  {
+    type: 'web_search_tool_result'
+    tool_use_id: string
+    content: unknown
+  } |
+  {
+    type: 'web_fetch_tool_result'
+    tool_use_id: string
+    content: unknown
+  } |
+  {
+    type: 'code_execution_tool_result'
+    tool_use_id: string
+    content: unknown
+  } |
+  {
+    type: 'bash_code_execution_tool_result'
+    tool_use_id: string
+    content: unknown
+  } |
+  {
+    type: 'text_editor_code_execution_tool_result'
+    tool_use_id: string
+    content: unknown
+  } |
+  {
+    type: 'tool_search_tool_result'
+    tool_use_id: string
+    content: unknown
+  } |
+  {
+    type: 'container_upload'
+    [key: string]: unknown
   }
 
 export interface ClaudeUsage {
@@ -170,7 +214,16 @@ export interface ClaudeUsage {
   output_tokens?: number
   cache_creation_input_tokens?: number
   cache_read_input_tokens?: number
-  service_tier?: string
+  server_tool_use?: {
+    web_search_requests: number
+    web_fetch_requests: number
+  } | null
+  cache_creation?: {
+    ephemeral_1h_input_tokens: number
+    ephemeral_5m_input_tokens: number
+  } | null
+  service_tier?: 'standard' | 'priority' | 'batch' | null
+  inference_geo?: string | null
 }
 
 // ---------- Tool call info (for correlating tool_use → tool_result) ----------

--- a/apps/api/src/engines/executors/claude/normalizer.ts
+++ b/apps/api/src/engines/executors/claude/normalizer.ts
@@ -180,7 +180,7 @@ export class ClaudeLogNormalizer {
       })
     }
 
-    // Thinking blocks
+    // Thinking blocks (including redacted)
     if (contentBlocks) {
       for (const block of contentBlocks) {
         if (block.type === 'thinking' && block.thinking) {
@@ -189,46 +189,127 @@ export class ClaudeLogNormalizer {
             content: block.thinking,
             timestamp: data.timestamp,
           })
+        } else if (block.type === 'redacted_thinking') {
+          entries.push({
+            entryType: 'thinking',
+            content: '[Thinking redacted]',
+            timestamp: data.timestamp,
+            metadata: { redacted: true },
+          })
         }
       }
     }
 
-    // Tool use blocks
+    // Tool use blocks (client-side and server-side)
     if (contentBlocks) {
       for (const block of contentBlocks) {
-        if (block.type !== 'tool_use' || !block.name) continue
+        // Client-side tool_use
+        if (block.type === 'tool_use' && block.name) {
+          const input = block.input ?? {}
+          const toolCallId = block.id ?? ''
 
-        const input = block.input ?? {}
-        const toolCallId = block.id ?? ''
+          if (toolCallId) {
+            this.toolMap.set(toolCallId, {
+              toolName: block.name,
+              input,
+              toolCallId,
+            })
+          }
 
-        // Register in tool map for later correlation
-        if (toolCallId) {
+          entries.push({
+            entryType: 'tool-use',
+            content: generateToolContent(block.name, input),
+            timestamp: data.timestamp,
+            metadata: {
+              messageId: data.message.id,
+              toolName: block.name,
+              input,
+              toolCallId,
+            },
+            toolAction: classifyToolAction(block.name, input),
+            toolDetail: {
+              kind: classifyToolKind(block.name),
+              toolName: block.name,
+              toolCallId,
+              isResult: false,
+              raw: input,
+            },
+          })
+        }
+
+        // Server-side tool_use (web_search, web_fetch, code_execution, etc.)
+        if (block.type === 'server_tool_use') {
+          const input = (typeof block.input === 'object' && block.input !== null ? block.input : {}) as Record<string, unknown>
+          const toolCallId = block.id
+
           this.toolMap.set(toolCallId, {
             toolName: block.name,
             input,
             toolCallId,
           })
+
+          entries.push({
+            entryType: 'tool-use',
+            content: generateToolContent(block.name, input),
+            timestamp: data.timestamp,
+            metadata: {
+              messageId: data.message.id,
+              toolName: block.name,
+              input,
+              toolCallId,
+              serverTool: true,
+            },
+            toolAction: classifyToolAction(block.name, input),
+            toolDetail: {
+              kind: classifyToolKind(block.name),
+              toolName: block.name,
+              toolCallId,
+              isResult: false,
+              raw: input,
+            },
+          })
         }
 
-        entries.push({
-          entryType: 'tool-use',
-          content: generateToolContent(block.name, input),
-          timestamp: data.timestamp,
-          metadata: {
-            messageId: data.message.id,
-            toolName: block.name,
-            input,
-            toolCallId,
-          },
-          toolAction: classifyToolAction(block.name, input),
-          toolDetail: {
-            kind: classifyToolKind(block.name),
-            toolName: block.name,
-            toolCallId,
-            isResult: false,
-            raw: input,
-          },
-        })
+        // Server tool result blocks
+        if (
+          block.type === 'web_search_tool_result'
+          || block.type === 'web_fetch_tool_result'
+          || block.type === 'code_execution_tool_result'
+          || block.type === 'bash_code_execution_tool_result'
+          || block.type === 'text_editor_code_execution_tool_result'
+          || block.type === 'tool_search_tool_result'
+        ) {
+          const toolUseId = block.tool_use_id
+          const info = this.toolMap.get(toolUseId)
+          if (info) this.toolMap.delete(toolUseId)
+
+          const resultContent = this.extractServerToolResultContent(block.type, block.content)
+          const isError = typeof block.content === 'object'
+            && block.content !== null
+            && 'type' in (block.content as Record<string, unknown>)
+            && String((block.content as Record<string, unknown>).type).endsWith('_error')
+
+          entries.push({
+            entryType: isError ? 'error-message' : 'tool-use',
+            content: resultContent,
+            timestamp: data.timestamp,
+            metadata: {
+              toolCallId: toolUseId,
+              toolName: info?.toolName,
+              isResult: true,
+              serverTool: true,
+            },
+            toolDetail: info
+              ? {
+                  kind: classifyToolKind(info.toolName),
+                  toolName: info.toolName,
+                  toolCallId: toolUseId,
+                  isResult: true,
+                  raw: buildToolResultRaw(info, resultContent, isError),
+                }
+              : undefined,
+          })
+        }
       }
     }
 
@@ -432,20 +513,94 @@ export class ClaudeLogNormalizer {
     // Emit token usage from message_delta if not from subagent
     if (!data.parent_tool_use_id && data.usage) {
       const input =
-        (data.usage.input_tokens ?? 0) +
-        (data.usage.cache_creation_input_tokens ?? 0) +
-        (data.usage.cache_read_input_tokens ?? 0)
+        (data.usage.input_tokens ?? 0)
+        + (data.usage.cache_creation_input_tokens ?? 0)
+        + (data.usage.cache_read_input_tokens ?? 0)
       const output = data.usage.output_tokens ?? 0
       if (input > 0 || output > 0) {
+        const metadata: Record<string, unknown> = {
+          inputTokens: input,
+          outputTokens: output,
+        }
+        // Include enriched usage fields when present
+        if (data.usage.service_tier) metadata.serviceTier = data.usage.service_tier
+        if (data.usage.inference_geo) metadata.inferenceGeo = data.usage.inference_geo
+        if (data.usage.server_tool_use) metadata.serverToolUse = data.usage.server_tool_use
+        if (data.usage.cache_creation) metadata.cacheCreation = data.usage.cache_creation
+
         return {
           entryType: 'token-usage',
           content: `${input} input · ${output} output`,
           timestamp: data.timestamp,
-          metadata: { inputTokens: input, outputTokens: output },
+          metadata,
         }
       }
     }
     return null
+  }
+
+  /** Extract human-readable content from server tool result blocks. */
+  private extractServerToolResultContent(blockType: string, content: unknown): string {
+    if (!content || typeof content !== 'object') return `${blockType}: (empty)`
+
+    // Error result (all server tool errors share *_error type suffix)
+    const contentObj = content as Record<string, unknown>
+    if (typeof contentObj.type === 'string' && contentObj.type.endsWith('_error')) {
+      return `Error: ${contentObj.error_code ?? contentObj.type}${contentObj.error_message ? ` — ${contentObj.error_message}` : ''}`
+    }
+
+    switch (blockType) {
+      case 'web_search_tool_result':
+        // Array of WebSearchResultBlock
+        if (Array.isArray(content)) {
+          return content
+            .map((r: Record<string, unknown>) => r.title ?? r.url ?? '')
+            .filter(Boolean)
+            .join(', ') || 'Web search completed'
+        }
+        return 'Web search completed'
+
+      case 'web_fetch_tool_result': {
+        // WebFetchBlock — extract text from nested structure
+        if ('page_content' in contentObj && typeof contentObj.page_content === 'string') {
+          return contentObj.page_content.slice(0, 500)
+        }
+        if ('content' in contentObj) {
+          const inner = contentObj.content
+          if (typeof inner === 'string') return inner.slice(0, 500)
+          if (typeof inner === 'object' && inner !== null) {
+            const innerObj = inner as Record<string, unknown>
+            // { type: 'web_fetch_result', content: "..." } or { page_content: "..." }
+            if (typeof innerObj.page_content === 'string') return innerObj.page_content.slice(0, 500)
+            if (typeof innerObj.content === 'string') return innerObj.content.slice(0, 500)
+            return JSON.stringify(inner).slice(0, 500)
+          }
+        }
+        return 'Web fetch completed'
+      }
+
+      case 'code_execution_tool_result':
+      case 'bash_code_execution_tool_result': {
+        // CodeExecutionResultBlock with stdout/stderr
+        const stdout = contentObj.stdout ?? ''
+        const stderr = contentObj.stderr ?? ''
+        const rc = contentObj.return_code
+        const parts: string[] = []
+        if (stdout) parts.push(String(stdout).slice(0, 500))
+        if (stderr) parts.push(`stderr: ${String(stderr).slice(0, 200)}`)
+        if (rc !== undefined && rc !== 0) parts.push(`exit: ${rc}`)
+        return parts.join('\n') || 'Code execution completed'
+      }
+
+      case 'text_editor_code_execution_tool_result':
+        return 'Text editor operation completed'
+
+      case 'tool_search_tool_result':
+        return 'Tool search completed'
+
+      default:
+        return JSON.stringify(content).slice(0, 300)
+    }
   }
 
   // ---------- Result ----------

--- a/apps/api/src/engines/executors/claude/protocol.ts
+++ b/apps/api/src/engines/executors/claude/protocol.ts
@@ -401,15 +401,15 @@ export class ClaudeProtocolHandler {
 // ---------- Helpers ----------
 
 /** Map our PermissionPolicy to Claude SDK permission mode string. */
-function mapPermissionMode(policy: PermissionPolicy): 'bypassPermissions' | 'plan' | 'default' {
+function mapPermissionMode(policy: PermissionPolicy): 'auto' | 'bypassPermissions' | 'plan' | 'default' {
   switch (policy) {
     case 'auto':
-      return 'bypassPermissions'
+      return 'auto'
     case 'plan':
       return 'plan'
     case 'supervised':
       return 'default'
     default:
-      return 'bypassPermissions'
+      return 'auto'
   }
 }

--- a/apps/api/src/engines/issue/constants.ts
+++ b/apps/api/src/engines/issue/constants.ts
@@ -4,13 +4,13 @@ export const MAX_LOG_ENTRIES = 10000
 export const AUTO_CLEANUP_DELAY_MS = 5 * 60 * 1000 // 5 minutes
 export const MAX_AUTO_RETRIES = 1
 // Stall detection timeline:
-//   T+2m: first check — if process alive, wait for CLI internal retry
-//   T+4m: second check (process alive 2min after first probe) — send interrupt
-//   T+6m: no response after interrupt — force kill
+//   T+3m: first check — if process alive, wait for CLI internal retry
+//   T+5m: second check (process alive 2min after first probe) — send interrupt
+//   T+7m: no response after interrupt — force kill
 export const GC_INTERVAL_MS = 60 * 1000 // 1 minute — frequent stall detection
 export const MAX_CONCURRENT_EXECUTIONS = Number(process.env.MAX_CONCURRENT_EXECUTIONS) || 5
 export const IDLE_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes
-export const STREAM_STALL_TIMEOUT_MS = 2 * 60 * 1000 // 2 minutes — check process liveness (non-destructive)
+export const STREAM_STALL_TIMEOUT_MS = 3 * 60 * 1000 // 3 minutes — check process liveness (non-destructive)
 export const STALL_LIVENESS_GRACE_MS = 2 * 60 * 1000 // 2 minutes — wait for CLI internal retry before sending interrupt
 export const STALL_INTERRUPT_GRACE_MS = 2 * 60 * 1000 // 2 minutes — kill process if no response after interrupt
 export const CANCEL_RESPONSE_TIMEOUT_MS = 5_000 // 5s — wait for turn completion after each interrupt retry

--- a/apps/api/src/mcp/config.ts
+++ b/apps/api/src/mcp/config.ts
@@ -41,9 +41,9 @@ export async function getClaudeMcpConfig(): Promise<string | null> {
 
 /**
  * Build the MCP server config for ACP protocol's mcpServers parameter.
- * Returns the server list, or empty array if MCP is disabled.
+ * Returns the server list matching the ACP SDK McpServer type.
  */
-export async function getAcpMcpServers(): Promise<Array<{ name: string, uri: string }>> {
+export async function getAcpMcpServers(): Promise<Array<{ type: 'http', name: string, url: string, headers: Array<{ name: string, value: string }> }>> {
   if (!await isMcpEnabled()) return []
-  return [{ name: 'bkd', uri: getMcpLocalUrl() }]
+  return [{ type: 'http', name: 'bkd', url: getMcpLocalUrl(), headers: [] }]
 }

--- a/apps/api/test/security-fs-hardening.test.ts
+++ b/apps/api/test/security-fs-hardening.test.ts
@@ -108,7 +108,8 @@ describe('files/:root/show browse and file content', () => {
     )
     expect(result.status).toBe(200)
     expect(result.json.success).toBe(true)
-    const names = result.json.data!.entries.map((e: { name: string }) => e.name)
+    if (!result.json.success) throw new Error('unreachable')
+    const names = result.json.data.entries.map((e: { name: string }) => e.name)
     expect(names).toContain('test.txt')
     expect(names).toContain('subdir')
     expect(names).toContain('linked-dir')
@@ -120,8 +121,9 @@ describe('files/:root/show browse and file content', () => {
       `/api/files/${encoded}/show/test.txt`,
     )
     expect(result.status).toBe(200)
-    expect(result.json.data!.type).toBe('file')
-    expect(result.json.data!.content).toBe('hello workspace')
+    if (!result.json.success) throw new Error('unreachable')
+    expect(result.json.data.type).toBe('file')
+    expect(result.json.data.content).toBe('hello workspace')
   })
 
   test('rejects path traversal via relative path', async () => {


### PR DESCRIPTION
## Summary

- **Auto mode**: Switch Claude executor from `bypassPermissions` to `auto` permission mode, enabling the built-in AI classifier (Sonnet 4.6) as an additional safety layer. The stdio protocol handler remains as fallback approver.
- **Normalizer alignment**: Add support for all new content block types and enriched usage fields from Anthropic SDK v0.80.0, including server-side tools (`web_search`, `web_fetch`, `code_execution`), `redacted_thinking`, and detailed usage metadata.

## Test plan

- [x] Lint passes (`bun run lint`)
- [x] All 591 backend tests pass
- [ ] Verify auto mode works end-to-end with a Claude execution (classifier screens tool calls, fallback approver handles escalations)
- [ ] Verify plan mode still bootstraps with `bypassPermissions` and switches correctly on `ExitPlanMode`
- [ ] Test with a model that emits `server_tool_use` blocks (e.g. web search enabled) to verify normalizer handles them