### PR TITLE
fix: align codex normalizer with app-server v2 protocol

### DIFF
--- a/apps/api/src/engines/executors/codex/normalizer.ts
+++ b/apps/api/src/engines/executors/codex/normalizer.ts
@@ -94,7 +94,9 @@ export class CodexLogNormalizer {
         return this.handleReasoningSummaryTextDelta(data, now)
 
       case 'item/reasoning/summaryPartAdded':
-        return null // Section break — reset state handled via next delta
+        // New summary segment — reset so next summaryTextDelta starts fresh
+        this.thinkingText = ''
+        return null
 
       case 'item/plan/delta':
         return this.handlePlanDelta(data, now)

--- a/apps/api/src/engines/executors/codex/normalizer.ts
+++ b/apps/api/src/engines/executors/codex/normalizer.ts
@@ -4,33 +4,24 @@ import type { NormalizedLogEntry, ToolAction } from '@/engines/types'
 // ---------- Types for Codex event protocol ----------
 
 /**
- * Codex wraps events in `codex/event/*` notifications:
- * { method: "codex/event/xxx", params: { msg: { type: "...", ... }, ... } }
+ * Codex app-server uses standard JSON-RPC v2 notifications:
+ *   { method: "item/agentMessage/delta", params: { threadId, turnId, itemId, delta } }
+ *   { method: "item/started", params: { item: ThreadItem, threadId, turnId } }
+ *   { method: "item/completed", params: { item: ThreadItem, threadId, turnId } }
+ *   { method: "turn/started", params: { threadId, turn: Turn } }
+ *   { method: "turn/completed", params: { threadId, turn: Turn } }
  *
- * The `msg` field contains the actual event.
+ * The `codex/event/*` format only exists in mcp-server mode (not used here).
  */
-
-interface CodexEventParams {
-  msg?: {
-    type?: string
-    [key: string]: unknown
-  }
-  [key: string]: unknown
-}
 
 // ---------- Stateful normalizer ----------
 
 /**
- * Stateful Codex log normalizer that handles the `codex/event/*` protocol
- * and maintains per-item state for proper streaming updates.
- *
- * Modeled after the Rust reference implementation in `tmp/exec/src/executors/codex/normalize_logs.rs`.
+ * Stateful Codex log normalizer for the app-server v2 JSON-RPC protocol.
  */
 export class CodexLogNormalizer {
   private assistantText = ''
   private thinkingText = ''
-  /** Set to true once any codex/event message is seen, so legacy turn events can be skipped. */
-  private hasV2Events = false
 
   /**
    * Parse a single stdout line and return normalized log entries.
@@ -64,15 +55,10 @@ export class CodexLogNormalizer {
     // -- No method field — not a notification we handle --
     if (!method) return null
 
-    // -- codex/event/* notifications (new v2 protocol) --
-    if (method.startsWith('codex/event')) {
-      return this.handleCodexEvent(data, now)
-    }
-
-    // -- Legacy raw notifications --
+    // -- Standard v2 JSON-RPC notifications (primary path for app-server) --
     switch (method) {
       case 'item/agentMessage/delta':
-        return null // Skip individual deltas — use codex/event instead
+        return this.handleAgentMessageDelta(data, now)
 
       case 'item/started':
         return this.handleItemStarted(data, now)
@@ -87,10 +73,10 @@ export class CodexLogNormalizer {
         return this.handleFileChangeOutputDelta(data, now)
 
       case 'turn/started':
-        return this.hasV2Events ? null : this.handleTurnStarted(data, now)
+        return this.handleTurnStarted(data, now)
 
       case 'turn/completed':
-        return this.hasV2Events ? null : this.handleTurnCompleted(data, now)
+        return this.handleTurnCompleted(data, now)
 
       case 'thread/started':
         return this.handleThreadStarted(data, now)
@@ -102,880 +88,131 @@ export class CodexLogNormalizer {
         return this.handleError(data, now)
 
       case 'item/reasoning/textDelta':
+        return this.handleReasoningTextDelta(data, now)
+
       case 'item/reasoning/summaryTextDelta':
-        return null // Skip reasoning deltas
+        return this.handleReasoningSummaryTextDelta(data, now)
 
-      default:
-        return null
-    }
-  }
+      case 'item/reasoning/summaryPartAdded':
+        return null // Section break — reset state handled via next delta
 
-  // ---------- codex/event/* handler ----------
+      case 'item/plan/delta':
+        return this.handlePlanDelta(data, now)
 
-  private handleCodexEvent(
-    data: Record<string, unknown>,
-    now: string,
-  ): NormalizedLogEntry | NormalizedLogEntry[] | null {
-    this.hasV2Events = true
-    const params = data.params as CodexEventParams | undefined
-    const msg = params?.msg
-    if (!msg?.type) return null
+      case 'item/mcpToolCall/progress':
+        return null // Progress updates — no actionable data yet
 
-    const eventType = msg.type as string
-
-    switch (eventType) {
-      // --- Assistant message (streaming delta) ---
-      case 'agent_message_delta': {
-        const delta = (msg.delta as string) ?? ''
-        if (!delta) return null
-        this.thinkingText = ''
-        this.assistantText += delta
-        return {
-          entryType: 'assistant-message',
-          content: this.assistantText,
-          timestamp: now,
-          metadata: { streaming: true },
-        }
-      }
-
-      // --- Assistant message (complete) ---
-      case 'agent_message': {
-        const message = (msg.message as string) ?? ''
-        this.thinkingText = ''
-        this.assistantText = message
-        const entry: NormalizedLogEntry = {
-          entryType: 'assistant-message',
-          content: message,
-          timestamp: now,
-        }
-        // Reset for next message
-        this.assistantText = ''
-        return entry
-      }
-
-      // --- Reasoning (thinking) delta ---
-      case 'agent_reasoning_delta': {
-        const delta = (msg.delta as string) ?? ''
-        if (!delta) return null
-        this.assistantText = ''
-        this.thinkingText += delta
-        return {
-          entryType: 'thinking',
-          content: this.thinkingText,
-          timestamp: now,
-          metadata: { streaming: true },
-        }
-      }
-
-      // --- Reasoning (thinking) complete ---
-      case 'agent_reasoning': {
-        const text = (msg.text as string) ?? ''
-        this.assistantText = ''
-        this.thinkingText = text
-        const entry: NormalizedLogEntry = {
-          entryType: 'thinking',
-          content: text,
-          timestamp: now,
-        }
-        this.thinkingText = ''
-        return entry
-      }
-
-      // --- Reasoning section break ---
-      case 'agent_reasoning_section_break': {
-        this.assistantText = ''
-        this.thinkingText = ''
-        return null
-      }
-
-      // --- Command execution begin ---
-      case 'exec_command_begin': {
-        this.resetStreamingState()
-        const command = msg.command as string[] | undefined
-        const commandStr = command?.join(' ') ?? ''
-        if (!commandStr) return null
-        const callId = msg.call_id as string | undefined
-        const cwd = msg.cwd as string | undefined
-        const source = msg.source as string | undefined
-        const parsedCmd = msg.parsed_cmd as unknown[] | undefined
-        const description = extractParsedCmdDescription(parsedCmd)
-        const toolAction: ToolAction = {
-          kind: 'command-run',
-          command: commandStr,
-          category: classifyCommand(commandStr),
-        }
-        return {
-          entryType: 'tool-use',
-          content: `Tool: Bash`,
-          timestamp: now,
-          metadata: {
-            toolName: 'Bash',
-            toolCallId: callId,
-            input: {
-              command: commandStr,
-              ...(description && { description }),
-            },
-            ...(cwd && { cwd }),
-            ...(source && { source }),
-          },
-          toolAction,
-        }
-      }
-
-      // --- Command execution output delta ---
-      case 'exec_command_output_delta': {
-        const chunk = msg.chunk as string | undefined
-        const stream = msg.stream as string | undefined
-        if (!chunk) return null
-        return {
-          entryType: 'tool-use',
-          content: chunk,
-          timestamp: now,
-          metadata: {
-            isResult: true,
-            streaming: true,
-            outputStream: stream,
-          },
-        }
-      }
-
-      // --- Command execution end ---
-      case 'exec_command_end': {
-        const command = msg.command as string[] | undefined
-        const commandStr = command?.join(' ') ?? ''
-        const exitCode = msg.exit_code as number | undefined
-        const formattedOutput = (msg.formatted_output as string) ?? ''
-        const callId = msg.call_id as string | undefined
-        const duration = msg.duration as string | undefined
-        const toolAction: ToolAction = {
-          kind: 'command-run',
-          command: commandStr,
-          result: formattedOutput || undefined,
-          category: commandStr ? classifyCommand(commandStr) : 'other',
-        }
-        return {
-          entryType: 'tool-use',
-          content: formattedOutput,
-          timestamp: now,
-          metadata: {
-            toolName: 'Bash',
-            isResult: true,
-            toolCallId: callId,
-            exitCode,
-            ...(duration && { duration }),
-          },
-          toolAction,
-        }
-      }
-
-      // --- File patch begin ---
-      case 'patch_apply_begin': {
-        this.resetStreamingState()
-        const changes = msg.changes as Record<string, unknown> | undefined
-        const callId = msg.call_id as string | undefined
-        const autoApproved = msg.auto_approved as boolean | undefined
-        if (!changes) return null
-        const entries: NormalizedLogEntry[] = []
-        for (const [path, fileChange] of Object.entries(changes)) {
-          const input = codexFileChangeToInput(path, fileChange)
-          const toolAction: ToolAction = {
-            kind: 'file-edit',
-            path,
-          }
-          entries.push({
-            entryType: 'tool-use',
-            content: `Tool: Edit`,
-            timestamp: now,
-            metadata: {
-              toolName: 'Edit',
-              toolCallId: callId,
-              path,
-              input,
-              ...(autoApproved !== undefined && { autoApproved }),
-            },
-            toolAction,
-          })
-        }
-        return entries.length === 1 ? entries[0] : entries.length > 0 ? entries : null
-      }
-
-      // --- File patch end ---
-      case 'patch_apply_end': {
-        const success = msg.success as boolean | undefined
-        const callId = msg.call_id as string | undefined
-        const stdout = (msg.stdout as string) ?? ''
-        const stderr = (msg.stderr as string) ?? ''
-        const changes = msg.changes as Record<string, unknown> | undefined
-        // Build result content from stdout/stderr if available
-        const resultParts: string[] = []
-        if (stdout) resultParts.push(stdout)
-        if (stderr) resultParts.push(stderr)
-        const resultContent = resultParts.length > 0
-          ? resultParts.join('\n')
-          : (success ? 'Patch applied successfully' : 'Patch apply failed')
-        // Extract changed file paths for metadata
-        const changedPaths = changes ? Object.keys(changes) : undefined
-        return {
-          entryType: 'tool-use',
-          content: resultContent,
-          timestamp: now,
-          metadata: {
-            toolName: 'Edit',
-            isResult: true,
-            toolCallId: callId,
-            exitCode: success ? 0 : 1,
-            ...(changedPaths && { changedPaths }),
-          },
-        }
-      }
-
-      // --- Approval request for exec ---
-      case 'exec_approval_request': {
-        this.resetStreamingState()
-        const command = msg.command as string[] | undefined
-        const commandStr = command?.join(' ') ?? ''
-        const callId = msg.call_id as string | undefined
-        const cwd = msg.cwd as string | undefined
-        const reason = msg.reason as string | null | undefined
-        const parsedCmd = msg.parsed_cmd as unknown[] | undefined
-        const description = extractParsedCmdDescription(parsedCmd)
-        const toolAction: ToolAction = {
-          kind: 'command-run',
-          command: commandStr,
-          category: commandStr ? classifyCommand(commandStr) : 'other',
-        }
-        return {
-          entryType: 'tool-use',
-          content: `Tool: Bash`,
-          timestamp: now,
-          metadata: {
-            toolName: 'Bash',
-            toolCallId: callId,
-            input: {
-              command: commandStr,
-              ...(description && { description }),
-            },
-            ...(cwd && { cwd }),
-            ...(reason && { reason }),
-          },
-          toolAction,
-        }
-      }
-
-      // --- Approval request for file patch ---
-      case 'apply_patch_approval_request': {
-        this.resetStreamingState()
-        const changes = msg.changes as Record<string, unknown> | undefined
-        const callId = msg.call_id as string | undefined
-        const reason = msg.reason as string | null | undefined
-        if (!changes) return null
-        const entries: NormalizedLogEntry[] = []
-        for (const [path, fileChange] of Object.entries(changes)) {
-          const input = codexFileChangeToInput(path, fileChange)
-          entries.push({
-            entryType: 'tool-use',
-            content: `Tool: Edit`,
-            timestamp: now,
-            metadata: {
-              toolName: 'Edit',
-              toolCallId: callId,
-              path,
-              input,
-              ...(reason && { reason }),
-            },
-            toolAction: { kind: 'file-edit', path },
-          })
-        }
-        return entries.length === 1 ? entries[0] : entries.length > 0 ? entries : null
-      }
-
-      // --- MCP tool call begin ---
-      case 'mcp_tool_call_begin': {
-        this.resetStreamingState()
-        const invocation = msg.invocation as
-          | {
-            server?: string
-            tool?: string
-            arguments?: unknown
-          } |
-          undefined
-        if (!invocation) return null
-        const toolName = `mcp:${invocation.server ?? 'unknown'}:${invocation.tool ?? 'unknown'}`
-        return {
-          entryType: 'tool-use',
-          content: `Tool: ${toolName}`,
-          timestamp: now,
-          metadata: {
-            toolName,
-            toolCallId: msg.call_id as string | undefined,
-            input: invocation.arguments,
-          },
-          toolAction: {
-            kind: 'tool',
-            toolName,
-            arguments: invocation.arguments,
-          },
-        }
-      }
-
-      // --- MCP tool call end ---
-      // Schema: result is { Ok: CallToolResult } | { Err: string }
-      // CallToolResult = { content: Array<{type,text,...}>, isError?: boolean }
-      case 'mcp_tool_call_end': {
-        const invocation = msg.invocation as
-          | {
-            server?: string
-            tool?: string
-          } |
-          undefined
-        const rawResult = msg.result as Record<string, unknown> | undefined
-        const toolName = `mcp:${invocation?.server ?? 'unknown'}:${invocation?.tool ?? 'unknown'}`
-        const duration = msg.duration as string | undefined
-
-        // Unwrap Ok/Err envelope (schema: { Ok: CallToolResult } | { Err: string })
-        let callToolResult: { content?: unknown[], isError?: boolean, is_error?: boolean } | undefined
-        let isError = false
-        if (rawResult && 'Ok' in rawResult) {
-          callToolResult = rawResult.Ok as typeof callToolResult
-        } else if (rawResult && 'Err' in rawResult) {
-          isError = true
-        } else {
-          // Fallback: treat raw result as CallToolResult directly (backwards compat)
-          callToolResult = rawResult as typeof callToolResult
-        }
-
-        if (callToolResult) {
-          isError = callToolResult.isError ?? callToolResult.is_error ?? isError
-        }
-
-        // Extract text content from MCP result
-        let resultText = ''
-        if (callToolResult && Array.isArray(callToolResult.content)) {
-          resultText = callToolResult.content
-            .filter((block: unknown) => {
-              const b = block as Record<string, unknown>
-              return b?.type === 'text'
-            })
-            .map((block: unknown) => (block as Record<string, unknown>).text as string)
-            .join('\n')
-        }
-
-        // If it was an Err string, use that as content
-        if (isError && !resultText && rawResult && 'Err' in rawResult) {
-          resultText = String(rawResult.Err)
-        }
-
-        return {
-          entryType: 'tool-use',
-          content: resultText || (isError ? 'MCP tool call failed' : 'MCP tool call completed'),
-          timestamp: now,
-          metadata: {
-            toolName,
-            isResult: true,
-            toolCallId: msg.call_id as string | undefined,
-            exitCode: isError ? 1 : 0,
-            ...(duration && { duration }),
-          },
-          toolAction: {
-            kind: 'tool',
-            toolName,
-            result: resultText || undefined,
-          },
-        }
-      }
-
-      // --- Web search begin ---
-      case 'web_search_begin': {
-        this.resetStreamingState()
-        return {
-          entryType: 'tool-use',
-          content: 'Tool: WebSearch',
-          timestamp: now,
-          metadata: {
-            toolName: 'WebSearch',
-            toolCallId: msg.call_id as string | undefined,
-          },
-          toolAction: { kind: 'web-fetch', url: '...' },
-        }
-      }
-
-      // --- Web search end ---
-      case 'web_search_end': {
-        const query = (msg.query as string) ?? ''
-        const action = msg.action as string | Record<string, unknown> | undefined
-        const actionType = typeof action === 'string'
-          ? action
-          : (action as Record<string, unknown> | undefined)?.type as string | undefined
-        return {
-          entryType: 'tool-use',
-          content: query || 'Web search completed',
-          timestamp: now,
-          metadata: {
-            toolName: 'WebSearch',
-            isResult: true,
-            toolCallId: msg.call_id as string | undefined,
-            ...(actionType && { actionType }),
-          },
-          toolAction: { kind: 'web-fetch', url: query },
-        }
-      }
-
-      // --- View image tool call ---
-      case 'view_image_tool_call': {
-        this.resetStreamingState()
-        const path = (msg.path as string) ?? ''
-        return {
-          entryType: 'tool-use',
-          content: `View image: ${path}`,
-          timestamp: now,
-          metadata: { toolName: 'ViewImage', path },
-          toolAction: { kind: 'file-read', path },
-        }
-      }
-
-      // --- Plan delta (streaming plan text) ---
-      case 'plan_delta': {
-        const delta = (msg.delta as string) ?? ''
-        if (!delta) return null
-        this.thinkingText = ''
-        this.assistantText += delta
-        return {
-          entryType: 'assistant-message',
-          content: this.assistantText,
-          timestamp: now,
-          metadata: { streaming: true, isPlan: true },
-        }
-      }
-
-      // --- Plan update (todo-like step list) ---
-      case 'plan_update': {
-        this.resetStreamingState()
-        const plan = msg.plan as Array<{ step: string, status: string }> | undefined
-        const explanation = msg.explanation as string | undefined
-        if (!plan) return null
-        const content = explanation?.trim() || `Plan updated (${plan.length} steps)`
+      case 'model/rerouted': {
+        const p = (data.params ?? {}) as Record<string, unknown>
         return {
           entryType: 'system-message',
-          content,
-          timestamp: now,
-          metadata: { subtype: 'plan_update', plan },
-        }
-      }
-
-      // --- Stream error ---
-      case 'stream_error': {
-        const message = (msg.message as string) ?? 'Stream error'
-        return {
-          entryType: 'error-message',
-          content: `Stream error: ${message}`,
+          content: `Model rerouted from ${p.fromModel ?? ''} to ${p.toModel ?? ''}`,
           timestamp: now,
         }
       }
 
-      // --- Error ---
-      case 'error': {
-        const message = (msg.message as string) ?? 'Unknown error'
-        const errorInfo = msg.codex_error_info as string | Record<string, unknown> | null | undefined
-        const errorType = extractCodexErrorType(errorInfo)
-        return {
-          entryType: 'error-message',
-          content: `Error: ${message}`,
-          timestamp: now,
-          metadata: {
-            ...(errorType && { errorType }),
-          },
-        }
-      }
+      case 'thread/compacted':
+        return { entryType: 'system-message', content: 'Context compacted', timestamp: now }
 
-      // --- Warning ---
-      case 'warning': {
-        const message = (msg.message as string) ?? ''
-        if (!message) return null
-        return {
-          entryType: 'error-message',
-          content: message,
-          timestamp: now,
-        }
-      }
-
-      // --- Model reroute ---
-      case 'model_reroute': {
-        const fromModel = (msg.from_model as string) ?? ''
-        const toModel = (msg.to_model as string) ?? ''
-        return {
-          entryType: 'system-message',
-          content: `Model rerouted from ${fromModel} to ${toModel}`,
-          timestamp: now,
-        }
-      }
-
-      // --- Token count / context usage ---
-      case 'token_count': {
-        const info = msg.info as
-          | {
-            last_token_usage?: { total_tokens?: number, input_tokens?: number, output_tokens?: number }
-            model_context_window?: number
-          } |
-          undefined
-        const rateLimits = msg.rate_limits as Record<string, unknown> | null | undefined
-        if (!info?.last_token_usage) return null
-        const totalTokens = info.last_token_usage.total_tokens ?? 0
-        const contextWindow = info.model_context_window ?? 0
+      case 'thread/tokenUsage/updated': {
+        const p = (data.params ?? {}) as Record<string, unknown>
+        const usage = (p.usage ?? {}) as Record<string, unknown>
+        const totalTokens = (usage.inputTokens as number ?? 0) + (usage.outputTokens as number ?? 0)
+        const contextWindow = usage.contextWindow as number | undefined
+        if (!totalTokens) return null
         return {
           entryType: 'token-usage',
-          content: `Tokens: ${totalTokens} / Context: ${contextWindow}`,
+          content: `Tokens: ${totalTokens}${contextWindow ? ` / Context: ${contextWindow}` : ''}`,
           timestamp: now,
           metadata: {
             totalTokens,
-            contextWindow,
-            ...(info.last_token_usage.input_tokens != null && { inputTokens: info.last_token_usage.input_tokens }),
-            ...(info.last_token_usage.output_tokens != null && { outputTokens: info.last_token_usage.output_tokens }),
-            ...(rateLimits && { rateLimits }),
-          },
-        }
-      }
-
-      // --- Context compacted ---
-      case 'context_compacted': {
-        return {
-          entryType: 'system-message',
-          content: 'Context compacted',
-          timestamp: now,
-        }
-      }
-
-      // --- Session configured ---
-      case 'session_configured': {
-        const model = (msg.model as string) ?? ''
-        const sessionId = (msg.session_id as string) ?? ''
-        const modelProviderId = msg.model_provider_id as string | undefined
-        const cwd = msg.cwd as string | undefined
-        const approvalPolicy = msg.approval_policy as string | undefined
-        const reasoningEffort = msg.reasoning_effort as string | null | undefined
-        const forkedFromId = msg.forked_from_id as string | null | undefined
-        const threadName = msg.thread_name as string | undefined
-        const parts: string[] = []
-        if (model) parts.push(`model: ${model}`)
-        if (modelProviderId) parts.push(`provider: ${modelProviderId}`)
-        return {
-          entryType: 'system-message',
-          content: parts.length > 0 ? parts.join('  ') : 'Session configured',
-          timestamp: now,
-          metadata: {
-            subtype: 'session_configured',
-            sessionId,
-            model,
-            ...(modelProviderId && { modelProviderId }),
-            ...(cwd && { cwd }),
-            ...(approvalPolicy && { approvalPolicy }),
-            ...(reasoningEffort && { reasoningEffort }),
-            ...(forkedFromId && { forkedFromId }),
-            ...(threadName && { threadName }),
-          },
-        }
-      }
-
-      // --- Background event ---
-      case 'background_event': {
-        const message = (msg.message as string) ?? ''
-        if (!message) return null
-        return {
-          entryType: 'system-message',
-          content: `Background event: ${message}`,
-          timestamp: now,
-        }
-      }
-
-      // --- Turn started (v2 codex/event) ---
-      // Schema type discriminant is "task_started" in EventMsg but "turn_started" in our events
-      case 'turn_started':
-      case 'task_started': {
-        const turnId = msg.turn_id as string | undefined
-        const contextWindow = msg.model_context_window as number | null | undefined
-        const collabMode = msg.collaboration_mode_kind as string | undefined
-        return {
-          entryType: 'system-message',
-          content: 'Turn started',
-          timestamp: now,
-          metadata: {
-            subtype: 'turn_started',
-            ...(turnId && { turnId }),
             ...(contextWindow != null && { contextWindow }),
-            ...(collabMode && { collabMode }),
+            inputTokens: usage.inputTokens as number | undefined,
+            outputTokens: usage.outputTokens as number | undefined,
           },
         }
       }
-
-      // --- Turn complete (v2 codex/event) ---
-      // Schema type discriminant is "task_complete" in EventMsg but "turn_complete" in our events
-      // Note: last_agent_message is NOT used as content because the same text was already
-      // streamed via agent_message_delta / agent_message events as assistant-message entries.
-      // Using it here would produce a duplicate system-message with identical content.
-      case 'turn_complete':
-      case 'task_complete': {
-        this.resetStreamingState()
-        const turnId = msg.turn_id as string | undefined
-        return {
-          entryType: 'system-message',
-          content: 'Turn completed',
-          timestamp: now,
-          metadata: {
-            turnCompleted: true,
-            ...(turnId && { turnId }),
-          },
-        }
-      }
-
-      // --- Item started (plan item) ---
-      case 'item_started': {
-        const item = msg.item as Record<string, unknown> | undefined
-        if (item?.type === 'plan' || item?.type === 'Plan') {
-          this.resetStreamingState()
-          return {
-            entryType: 'system-message',
-            content: 'Plan generation started',
-            timestamp: now,
-            metadata: { subtype: 'plan_started', itemId: item.id },
-          }
-        }
-        return null
-      }
-
-      // --- Item completed (plan item) ---
-      case 'item_completed': {
-        const item = msg.item as Record<string, unknown> | undefined
-        if (item?.type === 'plan' || item?.type === 'Plan') {
-          const text = (item.text as string) ?? ''
-          if (text) {
-            return {
-              entryType: 'assistant-message',
-              content: text,
-              timestamp: now,
-              metadata: { isPlan: true },
-            }
-          }
-        }
-        return null
-      }
-
-      // --- Request user input (interactive questions) ---
-      case 'request_user_input': {
-        const callId = msg.call_id as string | undefined
-        const questions = msg.questions as Array<{ question?: string, header?: string }> | undefined
-        const questionText = questions?.map(q => q.question || q.header || '').filter(Boolean).join('\n') || 'User input requested'
-        return {
-          entryType: 'system-message',
-          content: questionText,
-          timestamp: now,
-          metadata: {
-            subtype: 'request_user_input',
-            toolCallId: callId,
-            questions,
-          },
-        }
-      }
-
-      // --- Dynamic tool call request ---
-      case 'dynamic_tool_call_request': {
-        this.resetStreamingState()
-        const callId = msg.callId as string | undefined
-        const toolName = (msg.tool as string) ?? 'unknown'
-        const args = msg.arguments
-        return {
-          entryType: 'tool-use',
-          content: `Tool: ${toolName}`,
-          timestamp: now,
-          metadata: {
-            toolName,
-            toolCallId: callId,
-            input: args,
-          },
-          toolAction: {
-            kind: 'tool',
-            toolName,
-            arguments: args,
-          },
-        }
-      }
-
-      // --- Terminal interaction (interactive stdin) ---
-      case 'terminal_interaction': {
-        const callId = msg.call_id as string | undefined
-        const stdin = (msg.stdin as string) ?? ''
-        return {
-          entryType: 'system-message',
-          content: `Terminal input: ${stdin}`,
-          timestamp: now,
-          metadata: {
-            subtype: 'terminal_interaction',
-            toolCallId: callId,
-            processId: msg.process_id as string | undefined,
-          },
-        }
-      }
-
-      // --- Review mode events ---
-      case 'entered_review_mode': {
-        const hint = msg.user_facing_hint as string | undefined
-        return {
-          entryType: 'system-message',
-          content: hint || 'Entered review mode',
-          timestamp: now,
-          metadata: { subtype: 'entered_review_mode' },
-        }
-      }
-
-      case 'exited_review_mode': {
-        return {
-          entryType: 'system-message',
-          content: 'Exited review mode',
-          timestamp: now,
-          metadata: { subtype: 'exited_review_mode' },
-        }
-      }
-
-      // --- Collaboration events ---
-      case 'collab_agent_spawn_begin': {
-        const callId = msg.call_id as string | undefined
-        const prompt = (msg.prompt as string) ?? ''
-        return {
-          entryType: 'system-message',
-          content: prompt ? `Spawning agent: ${prompt.slice(0, 100)}` : 'Spawning agent',
-          timestamp: now,
-          metadata: {
-            subtype: 'collab_agent_spawn_begin',
-            toolCallId: callId,
-            senderThreadId: msg.sender_thread_id as string | undefined,
-          },
-        }
-      }
-
-      case 'collab_agent_spawn_end': {
-        const newThreadId = msg.new_thread_id as string | null | undefined
-        const status = msg.status as string | Record<string, unknown> | undefined
-        const statusStr = typeof status === 'string' ? status : 'unknown'
-        return {
-          entryType: 'system-message',
-          content: `Agent spawned: ${statusStr}`,
-          timestamp: now,
-          metadata: {
-            subtype: 'collab_agent_spawn_end',
-            ...(newThreadId && { newThreadId }),
-            agentStatus: status,
-          },
-        }
-      }
-
-      case 'collab_agent_interaction_begin': {
-        const callId = msg.call_id as string | undefined
-        const prompt = (msg.prompt as string) ?? ''
-        return {
-          entryType: 'system-message',
-          content: prompt ? `Agent interaction: ${prompt.slice(0, 100)}` : 'Agent interaction started',
-          timestamp: now,
-          metadata: {
-            subtype: 'collab_agent_interaction_begin',
-            toolCallId: callId,
-          },
-        }
-      }
-
-      case 'collab_agent_interaction_end': {
-        const status = msg.status as string | Record<string, unknown> | undefined
-        const statusStr = typeof status === 'string' ? status : 'completed'
-        return {
-          entryType: 'system-message',
-          content: `Agent interaction ended: ${statusStr}`,
-          timestamp: now,
-          metadata: { subtype: 'collab_agent_interaction_end', agentStatus: status },
-        }
-      }
-
-      case 'collab_waiting_begin': {
-        const receiverIds = msg.receiver_thread_ids as string[] | undefined
-        return {
-          entryType: 'system-message',
-          content: `Waiting for ${receiverIds?.length ?? 0} agent(s)`,
-          timestamp: now,
-          metadata: { subtype: 'collab_waiting_begin', receiverIds },
-        }
-      }
-
-      case 'collab_waiting_end': {
-        return {
-          entryType: 'system-message',
-          content: 'Agent wait completed',
-          timestamp: now,
-          metadata: { subtype: 'collab_waiting_end' },
-        }
-      }
-
-      // --- Elicitation request (MCP server asking for user input) ---
-      case 'elicitation_request': {
-        const serverName = (msg.server_name as string) ?? 'unknown'
-        const elicitMessage = (msg.message as string) ?? ''
-        return {
-          entryType: 'system-message',
-          content: elicitMessage || `MCP server ${serverName} requests input`,
-          timestamp: now,
-          metadata: {
-            subtype: 'elicitation_request',
-            serverName,
-          },
-        }
-      }
-
-      // --- Turn aborted ---
-      case 'turn_aborted': {
-        this.resetStreamingState()
-        return {
-          entryType: 'system-message',
-          content: 'Turn aborted',
-          timestamp: now,
-          metadata: { turnCompleted: true },
-        }
-      }
-
-      // --- Skip events (no useful data to extract) ---
-      case 'mcp_startup_update':
-      case 'mcp_startup_complete':
-      case 'mcp_list_tools_response':
-      case 'user_message':
-      case 'turn_diff':
-      case 'deprecation_notice':
-      case 'raw_response_item':
-      case 'undo_started':
-      case 'undo_completed':
-      case 'thread_rolled_back':
-      case 'thread_name_updated':
-      case 'shutdown_complete':
-      case 'get_history_entry_response':
-      case 'list_custom_prompts_response':
-      case 'list_skills_response':
-      case 'skills_update_available':
-      case 'agent_message_content_delta':
-      case 'reasoning_content_delta':
-      case 'reasoning_raw_content_delta':
-      case 'agent_reasoning_raw_content':
-      case 'agent_reasoning_raw_content_delta':
-      case 'collab_close_begin':
-      case 'collab_close_end':
-      case 'collab_resume_begin':
-      case 'collab_resume_end':
-      case 'dynamic_tool_call_response':
-      case 'list_remote_skills_response':
-      case 'remote_skill_downloaded':
-      case 'realtime_conversation_started':
-      case 'realtime_conversation_realtime':
-      case 'realtime_conversation_closed':
-        return null
 
       default:
         return null
     }
   }
 
-  // ---------- Legacy notification handlers (fallback) ----------
+  // ---------- v2 notification handlers ----------
+
+  /**
+   * Handle `item/agentMessage/delta` — streaming assistant message text.
+   * Wire format: { method: "item/agentMessage/delta", params: { threadId, turnId, itemId, delta } }
+   */
+  private handleAgentMessageDelta(data: Record<string, unknown>, now: string): NormalizedLogEntry | null {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const delta = params.delta as string | undefined
+    if (!delta) return null
+    this.thinkingText = ''
+    this.assistantText += delta
+    return {
+      entryType: 'assistant-message',
+      content: this.assistantText,
+      timestamp: now,
+      metadata: { streaming: true },
+    }
+  }
+
+  /**
+   * Handle `item/reasoning/textDelta` — streaming reasoning content.
+   * Wire format: { method: "item/reasoning/textDelta", params: { threadId, turnId, itemId, delta, contentIndex } }
+   */
+  private handleReasoningTextDelta(data: Record<string, unknown>, now: string): NormalizedLogEntry | null {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const delta = params.delta as string | undefined
+    if (!delta) return null
+    this.assistantText = ''
+    this.thinkingText += delta
+    return {
+      entryType: 'thinking',
+      content: this.thinkingText,
+      timestamp: now,
+      metadata: { streaming: true },
+    }
+  }
+
+  /**
+   * Handle `item/reasoning/summaryTextDelta` — streaming reasoning summary.
+   * Wire format: { method: "item/reasoning/summaryTextDelta", params: { threadId, turnId, itemId, delta, summaryIndex } }
+   */
+  private handleReasoningSummaryTextDelta(data: Record<string, unknown>, now: string): NormalizedLogEntry | null {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const delta = params.delta as string | undefined
+    if (!delta) return null
+    this.assistantText = ''
+    this.thinkingText += delta
+    return {
+      entryType: 'thinking',
+      content: this.thinkingText,
+      timestamp: now,
+      metadata: { streaming: true },
+    }
+  }
+
+  /**
+   * Handle `item/plan/delta` — streaming plan text.
+   * Wire format: { method: "item/plan/delta", params: { threadId, turnId, itemId, delta } }
+   */
+  private handlePlanDelta(data: Record<string, unknown>, now: string): NormalizedLogEntry | null {
+    const params = (data.params ?? {}) as Record<string, unknown>
+    const delta = params.delta as string | undefined
+    if (!delta) return null
+    this.thinkingText = ''
+    this.assistantText += delta
+    return {
+      entryType: 'assistant-message',
+      content: this.assistantText,
+      timestamp: now,
+      metadata: { streaming: true, isPlan: true },
+    }
+  }
+
+  // ---------- Response & legacy handlers ----------
 
   private handleResponse(data: Record<string, unknown>, now: string): NormalizedLogEntry | null {
     // Extract session ID from thread/start or thread/fork responses
@@ -1043,7 +280,103 @@ export class CodexLogNormalizer {
       }
     }
 
-    if (itemType === 'agentMessage' || itemType === 'reasoning') {
+    // McpToolCall: { type: "mcpToolCall", id, server, tool, arguments, status }
+    if (itemType === 'mcpToolCall') {
+      this.resetStreamingState()
+      const server = (item.server as string) ?? 'unknown'
+      const tool = (item.tool as string) ?? 'unknown'
+      const toolName = `mcp:${server}:${tool}`
+      return {
+        entryType: 'tool-use',
+        content: `Tool: ${toolName}`,
+        timestamp: now,
+        metadata: {
+          streaming: true,
+          toolName,
+          toolCallId: item.id as string | undefined,
+          input: item.arguments,
+        },
+        toolAction: { kind: 'tool', toolName, arguments: item.arguments },
+      }
+    }
+
+    // DynamicToolCall: { type: "dynamicToolCall", id, tool, arguments, status }
+    if (itemType === 'dynamicToolCall') {
+      this.resetStreamingState()
+      const toolName = (item.tool as string) ?? 'unknown'
+      return {
+        entryType: 'tool-use',
+        content: `Tool: ${toolName}`,
+        timestamp: now,
+        metadata: {
+          streaming: true,
+          toolName,
+          toolCallId: item.id as string | undefined,
+          input: item.arguments,
+        },
+        toolAction: { kind: 'tool', toolName, arguments: item.arguments },
+      }
+    }
+
+    // WebSearch: { type: "webSearch", id, query, action? }
+    if (itemType === 'webSearch') {
+      this.resetStreamingState()
+      const query = (item.query as string) ?? ''
+      return {
+        entryType: 'tool-use',
+        content: 'Tool: WebSearch',
+        timestamp: now,
+        metadata: {
+          streaming: true,
+          toolName: 'WebSearch',
+          toolCallId: item.id as string | undefined,
+          input: query ? { query } : undefined,
+        },
+        toolAction: { kind: 'web-fetch', url: query },
+      }
+    }
+
+    // CollabAgentToolCall: { type: "collabAgentToolCall", id, tool, status, prompt? }
+    if (itemType === 'collabAgentToolCall') {
+      this.resetStreamingState()
+      const tool = (item.tool as string) ?? 'unknown'
+      const prompt = (item.prompt as string) ?? ''
+      return {
+        entryType: 'system-message',
+        content: prompt ? `Agent ${tool}: ${prompt.slice(0, 100)}` : `Agent ${tool}`,
+        timestamp: now,
+        metadata: {
+          subtype: 'collab_tool_call',
+          toolCallId: item.id as string | undefined,
+          tool,
+        },
+      }
+    }
+
+    // ImageView: { type: "imageView", id, path }
+    if (itemType === 'imageView') {
+      this.resetStreamingState()
+      const path = (item.path as string) ?? ''
+      return {
+        entryType: 'tool-use',
+        content: `View image: ${path}`,
+        timestamp: now,
+        metadata: { toolName: 'ViewImage', toolCallId: item.id as string | undefined, path },
+        toolAction: { kind: 'file-read', path },
+      }
+    }
+
+    // AgentMessage / Reasoning / Plan — text arrives via streaming deltas + item/completed.
+    // Reset streaming state so stale text from a previous item doesn't leak.
+    if (itemType === 'agentMessage' || itemType === 'reasoning' || itemType === 'plan') {
+      this.resetStreamingState()
+      return null
+    }
+
+    // EnteredReviewMode / ExitedReviewMode / ContextCompaction / ImageGeneration
+    // — no useful started state (handled on completed)
+    if (itemType === 'enteredReviewMode' || itemType === 'exitedReviewMode'
+      || itemType === 'contextCompaction' || itemType === 'imageGeneration') {
       return null
     }
 
@@ -1107,12 +440,191 @@ export class CodexLogNormalizer {
       }
     }
 
-    // Skip legacy agentMessage — handled by codex/event/agent_message (v2)
+    // ThreadItem::AgentMessage: { type: "agentMessage", id, text, phase?, memoryCitation? }
     if (itemType === 'agentMessage') {
-      return null
+      const text = (item.text as string) ?? ''
+      if (!text) return null
+      this.assistantText = ''
+      this.thinkingText = ''
+      return {
+        entryType: 'assistant-message',
+        content: text,
+        timestamp: now,
+      }
     }
 
-    if (itemType === 'reasoning') return null
+    // ThreadItem::Reasoning: { type: "reasoning", id, summary: string[], content: string[] }
+    if (itemType === 'reasoning') {
+      const summary = item.summary as string[] | undefined
+      const content = item.content as string[] | undefined
+      const text = summary?.join('\n') || content?.join('\n') || ''
+      if (!text) return null
+      this.assistantText = ''
+      this.thinkingText = ''
+      return {
+        entryType: 'thinking',
+        content: text,
+        timestamp: now,
+      }
+    }
+
+    // McpToolCall: { type: "mcpToolCall", id, server, tool, result?, error?, durationMs?, status }
+    if (itemType === 'mcpToolCall') {
+      const server = (item.server as string) ?? 'unknown'
+      const tool = (item.tool as string) ?? 'unknown'
+      const toolName = `mcp:${server}:${tool}`
+      const error = item.error as { message?: string } | undefined
+      const result = item.result as { content?: unknown[] } | undefined
+      const durationMs = item.durationMs as number | undefined
+      let resultText = ''
+      if (result?.content && Array.isArray(result.content)) {
+        resultText = result.content
+          .filter((b: unknown) => (b as Record<string, unknown>)?.type === 'text')
+          .map((b: unknown) => (b as Record<string, string>).text)
+          .join('\n')
+      }
+      const isError = !!error || item.status === 'failed'
+      return {
+        entryType: 'tool-use',
+        content: resultText || error?.message || (isError ? 'MCP tool call failed' : 'MCP tool call completed'),
+        timestamp: now,
+        metadata: {
+          toolName,
+          isResult: true,
+          toolCallId: item.id as string | undefined,
+          exitCode: isError ? 1 : 0,
+          ...(durationMs != null && { duration: durationMs }),
+        },
+        toolAction: { kind: 'tool', toolName, result: resultText || undefined },
+      }
+    }
+
+    // DynamicToolCall: { type: "dynamicToolCall", id, tool, contentItems?, success?, durationMs?, status }
+    if (itemType === 'dynamicToolCall') {
+      const toolName = (item.tool as string) ?? 'unknown'
+      const contentItems = item.contentItems as Array<{ type?: string, text?: string }> | undefined
+      const durationMs = item.durationMs as number | undefined
+      const isError = item.success === false || item.status === 'failed'
+      const resultText = contentItems
+        ?.filter(c => c.type === 'text')
+        .map(c => c.text ?? '')
+        .join('\n') ?? ''
+      return {
+        entryType: 'tool-use',
+        content: resultText || (isError ? 'Tool call failed' : 'Tool call completed'),
+        timestamp: now,
+        metadata: {
+          toolName,
+          isResult: true,
+          toolCallId: item.id as string | undefined,
+          exitCode: isError ? 1 : 0,
+          ...(durationMs != null && { duration: durationMs }),
+        },
+        toolAction: { kind: 'tool', toolName, result: resultText || undefined },
+      }
+    }
+
+    // WebSearch: { type: "webSearch", id, query, action? }
+    if (itemType === 'webSearch') {
+      const query = (item.query as string) ?? ''
+      const action = item.action as { type?: string } | undefined
+      return {
+        entryType: 'tool-use',
+        content: query || 'Web search completed',
+        timestamp: now,
+        metadata: {
+          toolName: 'WebSearch',
+          isResult: true,
+          toolCallId: item.id as string | undefined,
+          ...(action?.type && { actionType: action.type }),
+        },
+        toolAction: { kind: 'web-fetch', url: query },
+      }
+    }
+
+    // CollabAgentToolCall: { type: "collabAgentToolCall", id, tool, status, agentsStates? }
+    if (itemType === 'collabAgentToolCall') {
+      const tool = (item.tool as string) ?? 'unknown'
+      const status = (item.status as string) ?? 'completed'
+      return {
+        entryType: 'system-message',
+        content: `Agent ${tool}: ${status}`,
+        timestamp: now,
+        metadata: { subtype: 'collab_tool_call', toolCallId: item.id as string | undefined, tool },
+      }
+    }
+
+    // Plan: { type: "plan", id, text }
+    if (itemType === 'plan') {
+      const text = (item.text as string) ?? ''
+      if (!text) return null
+      return {
+        entryType: 'assistant-message',
+        content: text,
+        timestamp: now,
+        metadata: { isPlan: true },
+      }
+    }
+
+    // ImageView: { type: "imageView", id, path }
+    if (itemType === 'imageView') {
+      const path = (item.path as string) ?? ''
+      return {
+        entryType: 'tool-use',
+        content: `View image: ${path}`,
+        timestamp: now,
+        metadata: { toolName: 'ViewImage', isResult: true, toolCallId: item.id as string | undefined, path },
+        toolAction: { kind: 'file-read', path },
+      }
+    }
+
+    // ImageGeneration: { type: "imageGeneration", id, status, result, revisedPrompt?, savedPath? }
+    if (itemType === 'imageGeneration') {
+      const result = (item.result as string) ?? ''
+      const savedPath = item.savedPath as string | undefined
+      return {
+        entryType: 'tool-use',
+        content: savedPath ? `Image saved: ${savedPath}` : 'Image generated',
+        timestamp: now,
+        metadata: {
+          toolName: 'ImageGeneration',
+          isResult: true,
+          toolCallId: item.id as string | undefined,
+          ...(savedPath && { path: savedPath }),
+          ...(result && { result }),
+        },
+      }
+    }
+
+    // EnteredReviewMode: { type: "enteredReviewMode", id, review }
+    if (itemType === 'enteredReviewMode') {
+      return {
+        entryType: 'system-message',
+        content: (item.review as string) || 'Entered review mode',
+        timestamp: now,
+        metadata: { subtype: 'entered_review_mode' },
+      }
+    }
+
+    // ExitedReviewMode: { type: "exitedReviewMode", id, review }
+    if (itemType === 'exitedReviewMode') {
+      return {
+        entryType: 'system-message',
+        content: 'Exited review mode',
+        timestamp: now,
+        metadata: { subtype: 'exited_review_mode' },
+      }
+    }
+
+    // ContextCompaction: { type: "contextCompaction", id }
+    if (itemType === 'contextCompaction') {
+      return {
+        entryType: 'system-message',
+        content: 'Context compacted',
+        timestamp: now,
+      }
+    }
+
     return null
   }
 
@@ -1244,79 +756,6 @@ export class CodexLogNormalizer {
     this.assistantText = ''
     this.thinkingText = ''
   }
-}
-
-/**
- * Map a Codex FileChange value to a frontend-compatible input object.
- *
- * Codex FileChange types:
- * - { type: "add", content: string }        → new file (Write-like)
- * - { type: "update", unified_diff: string } → file edit with unified diff
- * - { type: "delete", content: string }      → file deletion
- */
-function codexFileChangeToInput(
-  path: string,
-  fileChange: unknown,
-): Record<string, unknown> {
-  const base: Record<string, unknown> = { file_path: path }
-  if (!fileChange || typeof fileChange !== 'object') return base
-
-  const fc = fileChange as Record<string, unknown>
-  const changeType = fc.type as string | undefined
-
-  switch (changeType) {
-    case 'add':
-      if (typeof fc.content === 'string') {
-        base.content = fc.content
-      }
-      break
-    case 'update':
-      if (typeof fc.unified_diff === 'string') {
-        base.unified_diff = fc.unified_diff
-      }
-      break
-    case 'delete':
-      base.deleted = true
-      break
-  }
-
-  return base
-}
-
-/**
- * Extract a human-readable description from parsed_cmd array.
- * ParsedCommand: { type: "read", path } | { type: "list_files", path } |
- *                { type: "search", query, path } | { type: "unknown", cmd }
- */
-function extractParsedCmdDescription(parsedCmd: unknown[] | undefined): string | undefined {
-  if (!parsedCmd || parsedCmd.length === 0) return undefined
-  const first = parsedCmd[0] as Record<string, unknown> | undefined
-  if (!first) return undefined
-  switch (first.type) {
-    case 'read':
-      return `Read ${first.path ?? first.name ?? ''}`
-    case 'list_files':
-      return `List files${first.path ? ` in ${first.path}` : ''}`
-    case 'search':
-      return `Search${first.query ? ` "${first.query}"` : ''}${first.path ? ` in ${first.path}` : ''}`
-    default:
-      return undefined
-  }
-}
-
-/**
- * Extract a simplified error type string from CodexErrorInfo.
- * CodexErrorInfo is either a plain string like "context_window_exceeded"
- * or an object like { http_connection_failed: { http_status_code: 429 } }.
- */
-function extractCodexErrorType(errorInfo: unknown): string | undefined {
-  if (!errorInfo) return undefined
-  if (typeof errorInfo === 'string') return errorInfo
-  if (typeof errorInfo === 'object') {
-    const keys = Object.keys(errorInfo as Record<string, unknown>)
-    return keys[0] || undefined
-  }
-  return undefined
 }
 
 /**

--- a/apps/api/test/codex-normalize-log.test.ts
+++ b/apps/api/test/codex-normalize-log.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { CodexExecutor, CodexLogNormalizer } from '@/engines/executors/codex'
+import { CodexExecutor } from '@/engines/executors/codex'
 import type { NormalizedLogEntry } from '@/engines/types'
 
 const executor = new CodexExecutor()
@@ -15,28 +15,19 @@ function normalize(method: string, params?: Record<string, unknown>) {
   return asSingleEntry(executor.normalizeLog(JSON.stringify({ method, params })))
 }
 
-function parseSingle(normalizer: CodexLogNormalizer, rawLine: string) {
-  return asSingleEntry(normalizer.parse(rawLine))
-}
-
-/** Helper: build a codex/event/* notification line */
-function codexEvent(eventType: string, extra: Record<string, unknown> = {}) {
-  return JSON.stringify({
-    method: 'codex/event/xxx',
-    params: { msg: { type: eventType, ...extra } },
-  })
-}
-
 describe('CodexExecutor.normalizeLog', () => {
   // ------------------------------------------------------------------
   // 1. item/agentMessage/delta
   // ------------------------------------------------------------------
   describe('item/agentMessage/delta', () => {
-    test('returns null (canonical text emitted by item/completed)', () => {
+    test('returns streaming assistant-message with accumulated text', () => {
       const entry = normalize('item/agentMessage/delta', {
         delta: 'Hello world',
       })
-      expect(entry).toBeNull()
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('assistant-message')
+      expect(entry!.content).toBe('Hello world')
+      expect(entry!.metadata?.streaming).toBe(true)
     })
 
     test('returns null when delta is empty', () => {
@@ -167,11 +158,13 @@ describe('CodexExecutor.normalizeLog', () => {
       expect(entry!.content).toBe('File changed: /app/test.ts (1 patch)')
     })
 
-    test('agentMessage returns null (handled by v2 codex/event/agent_message)', () => {
+    test('agentMessage returns assistant-message with final text', () => {
       const entry = normalize('item/completed', {
         item: { type: 'agentMessage', text: 'Done!' },
       })
-      expect(entry).toBeNull()
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('assistant-message')
+      expect(entry!.content).toBe('Done!')
     })
 
     test('reasoning returns null', () => {
@@ -321,12 +314,20 @@ describe('CodexExecutor.normalizeLog', () => {
   // 8. Reasoning (skipped)
   // ------------------------------------------------------------------
   describe('reasoning', () => {
-    test('item/reasoning/textDelta returns null', () => {
-      expect(normalize('item/reasoning/textDelta', { delta: 'thinking...' })).toBeNull()
+    test('item/reasoning/textDelta returns streaming thinking entry', () => {
+      const entry = normalize('item/reasoning/textDelta', { delta: 'thinking...' })
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('thinking')
+      expect(entry!.content).toBe('thinking...')
+      expect(entry!.metadata?.streaming).toBe(true)
     })
 
-    test('item/reasoning/summaryTextDelta returns null', () => {
-      expect(normalize('item/reasoning/summaryTextDelta', { delta: 'summary' })).toBeNull()
+    test('item/reasoning/summaryTextDelta returns streaming thinking entry', () => {
+      const entry = normalize('item/reasoning/summaryTextDelta', { delta: 'summary' })
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('thinking')
+      expect(entry!.content).toBe('summary')
+      expect(entry!.metadata?.streaming).toBe(true)
     })
   })
 
@@ -368,889 +369,172 @@ describe('CodexExecutor.normalizeLog', () => {
       expect(() => new Date(entry!.timestamp!)).not.toThrow()
     })
   })
-})
-
-// ==================================================================
-// Stateful CodexLogNormalizer — codex/event/* protocol tests
-// ==================================================================
-describe('CodexLogNormalizer (codex/event/*)', () => {
-  // ------------------------------------------------------------------
-  // Streaming assistant message accumulation
-  // ------------------------------------------------------------------
-  describe('agent_message_delta (streaming)', () => {
-    test('accumulates deltas into full assistant-message', () => {
-      const n = new CodexLogNormalizer()
-      const r1 = parseSingle(n, codexEvent('agent_message_delta', { delta: 'Hello ' }))
-      expect(r1).not.toBeNull()
-      expect(r1!.entryType).toBe('assistant-message')
-      expect(r1!.content).toBe('Hello ')
-      expect(r1!.metadata?.streaming).toBe(true)
-
-      const r2 = parseSingle(n, codexEvent('agent_message_delta', { delta: 'world!' }))
-      expect(r2!.content).toBe('Hello world!')
-    })
-
-    test('empty delta returns null', () => {
-      const n = new CodexLogNormalizer()
-      expect(n.parse(codexEvent('agent_message_delta', { delta: '' }))).toBeNull()
-    })
-
-    test('resets thinking state when assistant delta arrives', () => {
-      const n = new CodexLogNormalizer()
-      n.parse(codexEvent('agent_reasoning_delta', { delta: 'thinking...' }))
-      const r = parseSingle(n, codexEvent('agent_message_delta', { delta: 'Hi' }))
-      expect(r!.entryType).toBe('assistant-message')
-      expect(r!.content).toBe('Hi')
-    })
-  })
-
-  describe('agent_message (complete)', () => {
-    test('returns complete assistant-message and resets state', () => {
-      const n = new CodexLogNormalizer()
-      // Accumulate some deltas first
-      n.parse(codexEvent('agent_message_delta', { delta: 'partial' }))
-      const r = parseSingle(n, codexEvent('agent_message', { message: 'Full message' }))
-      expect(r!.entryType).toBe('assistant-message')
-      expect(r!.content).toBe('Full message')
-      expect(r!.metadata?.streaming).toBeUndefined()
-
-      // Next delta should start fresh
-      const r2 = parseSingle(n, codexEvent('agent_message_delta', { delta: 'New' }))
-      expect(r2!.content).toBe('New')
-    })
-  })
 
   // ------------------------------------------------------------------
-  // Reasoning (thinking) events
+  // 10. MCP tool call
   // ------------------------------------------------------------------
-  describe('agent_reasoning_delta', () => {
-    test('accumulates thinking text', () => {
-      const n = new CodexLogNormalizer()
-      const r1 = parseSingle(n, codexEvent('agent_reasoning_delta', { delta: 'Let me ' }))
-      expect(r1!.entryType).toBe('thinking')
-      expect(r1!.content).toBe('Let me ')
-      expect(r1!.metadata?.streaming).toBe(true)
-
-      const r2 = parseSingle(n, codexEvent('agent_reasoning_delta', { delta: 'think...' }))
-      expect(r2!.content).toBe('Let me think...')
-    })
-  })
-
-  describe('agent_reasoning (complete)', () => {
-    test('returns complete thinking entry', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('agent_reasoning', { text: 'Full reasoning' }))
-      expect(r!.entryType).toBe('thinking')
-      expect(r!.content).toBe('Full reasoning')
-      expect(r!.metadata?.streaming).toBeUndefined()
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // Command execution events
-  // ------------------------------------------------------------------
-  describe('exec_command_begin', () => {
-    test('returns tool-use with command', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('exec_command_begin', {
-        command: ['git', 'status'],
-        call_id: 'call-1',
-      }))
-      expect(r!.entryType).toBe('tool-use')
-      expect(r!.content).toBe('Tool: Bash')
-      expect(r!.metadata?.toolName).toBe('Bash')
-      expect(r!.metadata?.toolCallId).toBe('call-1')
-      expect(r!.metadata?.input).toEqual({ command: 'git status' })
-      expect(r!.toolAction?.kind).toBe('command-run')
-    })
-
-    test('returns null for empty command', () => {
-      const n = new CodexLogNormalizer()
-      expect(n.parse(codexEvent('exec_command_begin', { command: [] }))).toBeNull()
-    })
-  })
-
-  describe('exec_command_output_delta', () => {
-    test('returns streaming tool output', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('exec_command_output_delta', {
-        chunk: 'output text',
-        stream: 'stdout',
-      }))
-      expect(r!.entryType).toBe('tool-use')
-      expect(r!.content).toBe('output text')
-      expect(r!.metadata?.streaming).toBe(true)
-      expect(r!.metadata?.outputStream).toBe('stdout')
-    })
-  })
-
-  describe('exec_command_end', () => {
-    test('returns tool result with exit code', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('exec_command_end', {
-        command: ['ls', '-la'],
-        exit_code: 0,
-        formatted_output: 'file1.ts\nfile2.ts',
-        call_id: 'call-2',
-      }))
-      expect(r!.entryType).toBe('tool-use')
-      expect(r!.content).toBe('file1.ts\nfile2.ts')
-      expect(r!.metadata?.isResult).toBe(true)
-      expect(r!.metadata?.exitCode).toBe(0)
-      expect(r!.toolAction?.kind).toBe('command-run')
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // File patch events
-  // ------------------------------------------------------------------
-  describe('patch_apply_begin', () => {
-    test('returns tool-use entries for each changed file', () => {
-      const n = new CodexLogNormalizer()
-      const r = n.parse(
-        codexEvent('patch_apply_begin', {
-          changes: {
-            '/app/a.ts': { type: 'add', content: 'new file content' },
-            '/app/b.ts': { type: 'update', unified_diff: '--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new' },
-          },
-          call_id: 'patch-1',
-        }),
-      )
-      expect(Array.isArray(r)).toBe(true)
-      const entries = r as any[]
-      expect(entries.length).toBe(2)
-      expect(entries[0].metadata?.path).toBe('/app/a.ts')
-      expect(entries[0].metadata?.input).toEqual({ file_path: '/app/a.ts', content: 'new file content' })
-      expect(entries[1].metadata?.path).toBe('/app/b.ts')
-      expect(entries[1].metadata?.input).toEqual({
-        file_path: '/app/b.ts',
-        unified_diff: '--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new',
+  describe('mcpToolCall', () => {
+    test('item/started mcpToolCall returns tool-use', () => {
+      const entry = normalize('item/started', {
+        item: { type: 'mcpToolCall', id: 'mcp-1', server: 'myserver', tool: 'mytool', arguments: { q: 'test' } },
       })
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('tool-use')
+      expect(entry!.metadata?.toolName).toBe('mcp:myserver:mytool')
+      expect(entry!.metadata?.input).toEqual({ q: 'test' })
     })
 
-    test('single file returns single entry (not array)', () => {
-      const n = new CodexLogNormalizer()
-      const r = n.parse(
-        codexEvent('patch_apply_begin', {
-          changes: { '/app/x.ts': { type: 'add', content: 'hello' } },
-        }),
-      )
-      expect(Array.isArray(r)).toBe(false)
-      expect((r as any).metadata?.path).toBe('/app/x.ts')
-      expect((r as any).metadata?.input?.content).toBe('hello')
-    })
-
-    test('delete type sets deleted flag', () => {
-      const n = new CodexLogNormalizer()
-      const r = n.parse(
-        codexEvent('patch_apply_begin', {
-          changes: { '/app/del.ts': { type: 'delete', content: 'old content' } },
-        }),
-      )
-      expect((r as any).metadata?.input).toEqual({ file_path: '/app/del.ts', deleted: true })
-    })
-
-    test('non-object fileChange falls back to path-only input', () => {
-      const n = new CodexLogNormalizer()
-      const r = n.parse(
-        codexEvent('patch_apply_begin', {
-          changes: { '/app/x.ts': '+line' },
-        }),
-      )
-      expect((r as any).metadata?.input).toEqual({ file_path: '/app/x.ts' })
-    })
-  })
-
-  describe('patch_apply_end', () => {
-    test('returns success result', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('patch_apply_end', { success: true }))
-      expect(r!.content).toBe('Patch applied successfully')
-      expect(r!.metadata?.exitCode).toBe(0)
-    })
-
-    test('returns failure result', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('patch_apply_end', { success: false }))
-      expect(r!.content).toBe('Patch apply failed')
-      expect(r!.metadata?.exitCode).toBe(1)
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // MCP tool call events
-  // ------------------------------------------------------------------
-  describe('mcp_tool_call_begin', () => {
-    test('returns tool-use with server:tool name', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('mcp_tool_call_begin', {
-        invocation: {
-          server: 'fs',
-          tool: 'readFile',
-          arguments: { path: '/tmp' },
+    test('item/completed mcpToolCall with result', () => {
+      const entry = normalize('item/completed', {
+        item: {
+          type: 'mcpToolCall',
+          id: 'mcp-1',
+          server: 'srv',
+          tool: 'tl',
+          status: 'completed',
+          result: { content: [{ type: 'text', text: 'result data' }] },
+          durationMs: 200,
         },
-      }))
-      expect(r!.metadata?.toolName).toBe('mcp:fs:readFile')
-      expect(r!.toolAction?.kind).toBe('tool')
-    })
-  })
-
-  describe('mcp_tool_call_end', () => {
-    test('extracts text content from result', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('mcp_tool_call_end', {
-        invocation: { server: 'fs', tool: 'readFile' },
-        result: {
-          content: [{ type: 'text', text: 'file contents' }],
-          is_error: false,
-        },
-      }))
-      expect(r!.content).toBe('file contents')
-      expect(r!.metadata?.exitCode).toBe(0)
-    })
-
-    test('handles error result', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('mcp_tool_call_end', {
-        invocation: { server: 'fs', tool: 'readFile' },
-        result: { is_error: true },
-      }))
-      expect(r!.content).toBe('MCP tool call failed')
-      expect(r!.metadata?.exitCode).toBe(1)
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // Error / warning / system events
-  // ------------------------------------------------------------------
-  describe('error and warning events', () => {
-    test('error returns error-message', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('error', { message: 'API error' }))
-      expect(r!.entryType).toBe('error-message')
-      expect(r!.content).toBe('Error: API error')
-    })
-
-    test('stream_error returns error-message', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('stream_error', { message: 'connection lost' }))
-      expect(r!.entryType).toBe('error-message')
-      expect(r!.content).toBe('Stream error: connection lost')
-    })
-
-    test('warning returns error-message', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('warning', { message: 'Deprecated API' }))
-      expect(r!.entryType).toBe('error-message')
-      expect(r!.content).toBe('Deprecated API')
-    })
-
-    test('warning with empty message returns null', () => {
-      const n = new CodexLogNormalizer()
-      expect(n.parse(codexEvent('warning', { message: '' }))).toBeNull()
-    })
-  })
-
-  describe('system events', () => {
-    test('model_reroute', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('model_reroute', {
-        from_model: 'gpt-4o',
-        to_model: 'gpt-5.3-codex',
-      }))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.content).toBe('Model rerouted from gpt-4o to gpt-5.3-codex')
-    })
-
-    test('token_count', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('token_count', {
-        info: {
-          last_token_usage: { total_tokens: 5000 },
-          model_context_window: 128000,
-        },
-      }))
-      expect(r!.entryType).toBe('token-usage')
-      expect(r!.metadata?.totalTokens).toBe(5000)
-      expect(r!.metadata?.contextWindow).toBe(128000)
-    })
-
-    test('context_compacted', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('context_compacted'))
-      expect(r!.content).toBe('Context compacted')
-    })
-
-    test('session_configured', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('session_configured', {
-        model: 'gpt-5.3-codex',
-        session_id: 'sess-123',
-      }))
-      expect(r!.content).toBe('model: gpt-5.3-codex')
-      expect(r!.metadata?.sessionId).toBe('sess-123')
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // Skipped events
-  // ------------------------------------------------------------------
-  describe('skipped events', () => {
-    const skipTypes = [
-      'mcp_startup_update',
-      'mcp_startup_complete',
-      'user_message',
-      'turn_diff',
-      'shutdown_complete',
-    ]
-    for (const type of skipTypes) {
-      test(`${type} returns null`, () => {
-        const n = new CodexLogNormalizer()
-        expect(n.parse(codexEvent(type))).toBeNull()
       })
-    }
-  })
-
-  // ------------------------------------------------------------------
-  // Streaming state reset on tool use
-  // ------------------------------------------------------------------
-  describe('streaming state management', () => {
-    test('exec_command_begin resets accumulated assistant text', () => {
-      const n = new CodexLogNormalizer()
-      n.parse(codexEvent('agent_message_delta', { delta: 'partial text' }))
-      n.parse(codexEvent('exec_command_begin', { command: ['ls'] }))
-      // Next delta should start fresh
-      const r = parseSingle(n, codexEvent('agent_message_delta', { delta: 'New' }))
-      expect(r!.content).toBe('New')
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('tool-use')
+      expect(entry!.content).toBe('result data')
+      expect(entry!.metadata?.isResult).toBe(true)
+      expect(entry!.metadata?.exitCode).toBe(0)
+      expect(entry!.metadata?.duration).toBe(200)
     })
 
-    test('agent_reasoning_section_break resets all state', () => {
-      const n = new CodexLogNormalizer()
-      n.parse(codexEvent('agent_reasoning_delta', { delta: 'thinking' }))
-      n.parse(codexEvent('agent_reasoning_section_break'))
-      const r = parseSingle(n, codexEvent('agent_reasoning_delta', { delta: 'fresh' }))
-      expect(r!.content).toBe('fresh')
-    })
-
-    test('plan_update resets assistant buffer so next delta starts fresh', () => {
-      const n = new CodexLogNormalizer()
-      n.parse(codexEvent('plan_delta', { delta: 'Step 1: do X' }))
-      n.parse(
-        codexEvent('plan_update', {
-          plan: [{ step: 'Step 1', status: 'done' }],
-        }),
-      )
-      // Next agent_message_delta should NOT include stale plan text
-      const r = parseSingle(n, codexEvent('agent_message_delta', { delta: 'Answer' }))
-      expect(r!.content).toBe('Answer')
-    })
-
-    test('turn_complete resets streaming state', () => {
-      const n = new CodexLogNormalizer()
-      n.parse(codexEvent('agent_message_delta', { delta: 'partial' }))
-      n.parse(codexEvent('turn_complete'))
-      // Next delta should start fresh
-      const r = parseSingle(n, codexEvent('agent_message_delta', { delta: 'New turn' }))
-      expect(r!.content).toBe('New turn')
+    test('item/completed mcpToolCall with error', () => {
+      const entry = normalize('item/completed', {
+        item: { type: 'mcpToolCall', id: 'mcp-2', server: 's', tool: 't', status: 'failed', error: { message: 'timeout' } },
+      })
+      expect(entry).not.toBeNull()
+      expect(entry!.content).toBe('timeout')
+      expect(entry!.metadata?.exitCode).toBe(1)
     })
   })
 
   // ------------------------------------------------------------------
-  // JSON-RPC response handling (session configured)
+  // 11. Dynamic tool call
   // ------------------------------------------------------------------
-  describe('JSON-RPC response handling', () => {
-    test('thread/start response with model emits session_configured', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, JSON.stringify({
-        id: 1,
-        result: { thread: { id: 'thr-1' }, model: 'gpt-5.3-codex' },
-      }))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.content).toBe('model: gpt-5.3-codex')
+  describe('dynamicToolCall', () => {
+    test('item/started dynamicToolCall returns tool-use', () => {
+      const entry = normalize('item/started', {
+        item: { type: 'dynamicToolCall', id: 'dt-1', tool: 'custom_tool', arguments: { x: 1 } },
+      })
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('tool-use')
+      expect(entry!.metadata?.toolName).toBe('custom_tool')
     })
 
-    test('response without thread returns null', () => {
-      const n = new CodexLogNormalizer()
-      expect(n.parse(JSON.stringify({ id: 1, result: {} }))).toBeNull()
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // Turn complete / turn started (v2 codex/event)
-  // ------------------------------------------------------------------
-  describe('turn_complete event', () => {
-    test('emits completion entry with turnCompleted metadata', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('turn_complete'))
-      expect(r).not.toBeNull()
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.metadata?.turnCompleted).toBe(true)
-    })
-
-    test('extracts turn_id and ignores last_agent_message (already streamed)', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('turn_complete', {
-        turn_id: 'turn-42',
-        last_agent_message: 'Done!',
-      }))
-      // last_agent_message is NOT used — the same text was already streamed via agent_message_delta
-      expect(r!.content).toBe('Turn completed')
-      expect(r!.metadata?.turnId).toBe('turn-42')
-    })
-
-    test('task_complete alias works', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('task_complete', { turn_id: 'tc-1' }))
-      expect(r!.metadata?.turnCompleted).toBe(true)
-      expect(r!.metadata?.turnId).toBe('tc-1')
-    })
-  })
-
-  describe('turn_started event', () => {
-    test('extracts turn_id and context window', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('turn_started', {
-        turn_id: 'ts-1',
-        model_context_window: 128000,
-        collaboration_mode_kind: 'default',
-      }))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.metadata?.turnId).toBe('ts-1')
-      expect(r!.metadata?.contextWindow).toBe(128000)
-      expect(r!.metadata?.collabMode).toBe('default')
-    })
-
-    test('task_started alias works', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('task_started', { turn_id: 'ts-2' }))
-      expect(r!.metadata?.subtype).toBe('turn_started')
-      expect(r!.metadata?.turnId).toBe('ts-2')
-    })
-  })
-
-  describe('turn_aborted event', () => {
-    test('emits system-message with turnCompleted', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('turn_aborted'))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.content).toBe('Turn aborted')
-      expect(r!.metadata?.turnCompleted).toBe(true)
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // Plan events
-  // ------------------------------------------------------------------
-  describe('plan events', () => {
-    test('plan_delta accumulates plan text', () => {
-      const n = new CodexLogNormalizer()
-      const r1 = parseSingle(n, codexEvent('plan_delta', { delta: 'Step 1: ' }))
-      expect(r1!.content).toBe('Step 1: ')
-      expect(r1!.metadata?.isPlan).toBe(true)
-
-      const r2 = parseSingle(n, codexEvent('plan_delta', { delta: 'do something' }))
-      expect(r2!.content).toBe('Step 1: do something')
-    })
-
-    test('plan_update with steps', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('plan_update', {
-        plan: [
-          { step: 'Read file', status: 'done' },
-          { step: 'Edit file', status: 'pending' },
-        ],
-        explanation: 'Updated plan',
-      }))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.content).toBe('Updated plan')
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // exec_command_begin enriched fields
-  // ------------------------------------------------------------------
-  describe('exec_command_begin enriched fields', () => {
-    test('includes cwd, source, and parsed_cmd description', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('exec_command_begin', {
-        command: ['cat', '/app/file.ts'],
-        call_id: 'c1',
-        cwd: '/app',
-        source: 'agent',
-        parsed_cmd: [{ type: 'read', cmd: 'cat', name: 'cat', path: '/app/file.ts' }],
-      }))
-      expect(r!.metadata?.cwd).toBe('/app')
-      expect(r!.metadata?.source).toBe('agent')
-      expect((r!.metadata?.input as { description?: string } | undefined)?.description).toBe('Read /app/file.ts')
-    })
-
-    test('parsed_cmd search type', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('exec_command_begin', {
-        command: ['grep', '-r', 'foo', '/app'],
-        call_id: 'c2',
-        parsed_cmd: [{ type: 'search', cmd: 'grep', query: 'foo', path: '/app' }],
-      }))
-      expect((r!.metadata?.input as { description?: string } | undefined)?.description).toBe('Search "foo" in /app')
-    })
-
-    test('parsed_cmd unknown type has no description', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('exec_command_begin', {
-        command: ['echo', 'hi'],
-        call_id: 'c3',
-        parsed_cmd: [{ type: 'unknown', cmd: 'echo' }],
-      }))
-      expect((r!.metadata?.input as { description?: string } | undefined)?.description).toBeUndefined()
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // exec_command_end enriched fields
-  // ------------------------------------------------------------------
-  describe('exec_command_end duration', () => {
-    test('includes duration string', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('exec_command_end', {
-        command: ['ls'],
-        exit_code: 0,
-        formatted_output: 'file1',
-        duration: '1.2s',
-      }))
-      expect(r!.metadata?.duration).toBe('1.2s')
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // patch_apply_begin enriched fields
-  // ------------------------------------------------------------------
-  describe('patch_apply_begin auto_approved', () => {
-    test('includes autoApproved metadata', () => {
-      const n = new CodexLogNormalizer()
-      const r = n.parse(
-        codexEvent('patch_apply_begin', {
-          changes: { '/app/x.ts': { type: 'add', content: 'hi' } },
-          auto_approved: true,
-        }),
-      )
-      expect((r as any).metadata?.autoApproved).toBe(true)
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // patch_apply_end enriched fields
-  // ------------------------------------------------------------------
-  describe('patch_apply_end enriched', () => {
-    test('includes stdout/stderr in content', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('patch_apply_end', {
-        success: true,
-        call_id: 'p1',
-        stdout: 'Applied 2 edits',
-        stderr: '',
-        changes: { '/app/a.ts': { type: 'update', unified_diff: 'diff' } },
-      }))
-      expect(r!.content).toBe('Applied 2 edits')
-      expect(r!.metadata?.changedPaths).toEqual(['/app/a.ts'])
-    })
-
-    test('falls back to default message when no stdout/stderr', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('patch_apply_end', { success: false }))
-      expect(r!.content).toBe('Patch apply failed')
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // exec_approval_request enriched fields
-  // ------------------------------------------------------------------
-  describe('exec_approval_request enriched', () => {
-    test('includes cwd and reason', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('exec_approval_request', {
-        command: ['rm', '-rf', '/tmp/build'],
-        call_id: 'ea-1',
-        cwd: '/app',
-        reason: 'Needs elevated permissions',
-        parsed_cmd: [{ type: 'unknown', cmd: 'rm' }],
-      }))
-      expect(r!.metadata?.cwd).toBe('/app')
-      expect(r!.metadata?.reason).toBe('Needs elevated permissions')
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // apply_patch_approval_request enriched fields
-  // ------------------------------------------------------------------
-  describe('apply_patch_approval_request enriched', () => {
-    test('includes reason', () => {
-      const n = new CodexLogNormalizer()
-      const r = n.parse(
-        codexEvent('apply_patch_approval_request', {
-          changes: { '/app/x.ts': { type: 'add', content: 'new' } },
-          call_id: 'pa-1',
-          reason: 'Write to protected path',
-        }),
-      )
-      expect((r as any).metadata?.reason).toBe('Write to protected path')
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // mcp_tool_call_end Ok/Err envelope
-  // ------------------------------------------------------------------
-  describe('mcp_tool_call_end Ok/Err envelope', () => {
-    test('unwraps Ok envelope', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('mcp_tool_call_end', {
-        invocation: { server: 'fs', tool: 'read' },
-        result: { Ok: { content: [{ type: 'text', text: 'contents' }] } },
-        duration: '0.5s',
-      }))
-      expect(r!.content).toBe('contents')
-      expect(r!.metadata?.exitCode).toBe(0)
-      expect(r!.metadata?.duration).toBe('0.5s')
-    })
-
-    test('unwraps Err envelope', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('mcp_tool_call_end', {
-        invocation: { server: 'fs', tool: 'read' },
-        result: { Err: 'file not found' },
-      }))
-      expect(r!.content).toBe('file not found')
-      expect(r!.metadata?.exitCode).toBe(1)
-    })
-
-    test('backwards compat: flat result without Ok/Err', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('mcp_tool_call_end', {
-        invocation: { server: 'fs', tool: 'read' },
-        result: { content: [{ type: 'text', text: 'flat' }], is_error: false },
-      }))
-      expect(r!.content).toBe('flat')
-      expect(r!.metadata?.exitCode).toBe(0)
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // session_configured enriched fields
-  // ------------------------------------------------------------------
-  describe('session_configured enriched', () => {
-    test('includes provider, cwd, approval policy', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('session_configured', {
-        model: 'o3',
-        session_id: 's1',
-        model_provider_id: 'openai',
-        cwd: '/app',
-        approval_policy: 'never',
-        reasoning_effort: 'high',
-        forked_from_id: 'parent-s1',
-        thread_name: 'my thread',
-      }))
-      expect(r!.content).toBe('model: o3  provider: openai')
-      expect(r!.metadata?.modelProviderId).toBe('openai')
-      expect(r!.metadata?.cwd).toBe('/app')
-      expect(r!.metadata?.approvalPolicy).toBe('never')
-      expect(r!.metadata?.reasoningEffort).toBe('high')
-      expect(r!.metadata?.forkedFromId).toBe('parent-s1')
-      expect(r!.metadata?.threadName).toBe('my thread')
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // error event with codex_error_info
-  // ------------------------------------------------------------------
-  describe('error with codex_error_info', () => {
-    test('extracts string error type', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('error', {
-        message: 'Context exceeded',
-        codex_error_info: 'context_window_exceeded',
-      }))
-      expect(r!.metadata?.errorType).toBe('context_window_exceeded')
-    })
-
-    test('extracts object error type key', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('error', {
-        message: 'HTTP error',
-        codex_error_info: { http_connection_failed: { http_status_code: 429 } },
-      }))
-      expect(r!.metadata?.errorType).toBe('http_connection_failed')
-    })
-
-    test('no error info has no errorType', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('error', { message: 'plain error' }))
-      expect(r!.metadata?.errorType).toBeUndefined()
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // token_count enriched fields
-  // ------------------------------------------------------------------
-  describe('token_count enriched', () => {
-    test('includes input/output tokens and rate limits', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('token_count', {
-        info: {
-          last_token_usage: { total_tokens: 5000, input_tokens: 3000, output_tokens: 2000 },
-          model_context_window: 128000,
+    test('item/completed dynamicToolCall with content', () => {
+      const entry = normalize('item/completed', {
+        item: {
+          type: 'dynamicToolCall',
+          id: 'dt-1',
+          tool: 'custom_tool',
+          status: 'completed',
+          success: true,
+          contentItems: [{ type: 'text', text: 'output' }],
         },
-        rate_limits: { requests_remaining: 10 },
-      }))
-      expect(r!.metadata?.inputTokens).toBe(3000)
-      expect(r!.metadata?.outputTokens).toBe(2000)
-      expect(r!.metadata?.rateLimits).toEqual({ requests_remaining: 10 })
+      })
+      expect(entry).not.toBeNull()
+      expect(entry!.content).toBe('output')
+      expect(entry!.metadata?.exitCode).toBe(0)
     })
   })
 
   // ------------------------------------------------------------------
-  // Interactive events (previously dropped)
+  // 12. Web search
   // ------------------------------------------------------------------
-  describe('request_user_input', () => {
-    test('returns system-message with questions', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('request_user_input', {
-        call_id: 'rui-1',
-        turn_id: 't1',
-        questions: [{ question: 'Do you want to proceed?' }],
-      }))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.content).toBe('Do you want to proceed?')
-      expect(r!.metadata?.subtype).toBe('request_user_input')
+  describe('webSearch', () => {
+    test('item/started webSearch returns tool-use', () => {
+      const entry = normalize('item/started', {
+        item: { type: 'webSearch', id: 'ws-1', query: 'typescript patterns' },
+      })
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('tool-use')
+      expect(entry!.metadata?.toolName).toBe('WebSearch')
     })
-  })
 
-  describe('dynamic_tool_call_request', () => {
-    test('returns tool-use entry', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('dynamic_tool_call_request', {
-        callId: 'dtc-1',
-        turnId: 't1',
-        tool: 'custom_tool',
-        arguments: { key: 'value' },
-      }))
-      expect(r!.entryType).toBe('tool-use')
-      expect(r!.metadata?.toolName).toBe('custom_tool')
-      expect(r!.metadata?.input).toEqual({ key: 'value' })
-    })
-  })
-
-  describe('terminal_interaction', () => {
-    test('returns system-message with stdin', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('terminal_interaction', {
-        call_id: 'ti-1',
-        process_id: 'pid-1',
-        stdin: 'yes\n',
-      }))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.content).toContain('yes')
-      expect(r!.metadata?.subtype).toBe('terminal_interaction')
-      expect(r!.metadata?.processId).toBe('pid-1')
+    test('item/completed webSearch returns result', () => {
+      const entry = normalize('item/completed', {
+        item: { type: 'webSearch', id: 'ws-1', query: 'typescript patterns', action: { type: 'search' } },
+      })
+      expect(entry).not.toBeNull()
+      expect(entry!.content).toBe('typescript patterns')
+      expect(entry!.metadata?.actionType).toBe('search')
     })
   })
 
   // ------------------------------------------------------------------
-  // Review mode events
+  // 13. Plan
   // ------------------------------------------------------------------
-  describe('review mode events', () => {
-    test('entered_review_mode returns system-message', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('entered_review_mode', { user_facing_hint: 'Review changes' }))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.content).toBe('Review changes')
-      expect(r!.metadata?.subtype).toBe('entered_review_mode')
+  describe('plan', () => {
+    test('item/plan/delta accumulates streaming text', () => {
+      const entry = normalize('item/plan/delta', { delta: 'Step 1' })
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('assistant-message')
+      expect(entry!.metadata?.isPlan).toBe(true)
+      expect(entry!.metadata?.streaming).toBe(true)
     })
 
-    test('exited_review_mode returns system-message', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('exited_review_mode'))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.content).toBe('Exited review mode')
-    })
-  })
-
-  // ------------------------------------------------------------------
-  // Collaboration events
-  // ------------------------------------------------------------------
-  describe('collaboration events', () => {
-    test('collab_agent_spawn_begin returns system-message with prompt', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('collab_agent_spawn_begin', {
-        call_id: 'cs-1',
-        sender_thread_id: 'sender-1',
-        prompt: 'Fix the bug in auth module',
-      }))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.content).toContain('Fix the bug')
-      expect(r!.metadata?.subtype).toBe('collab_agent_spawn_begin')
-    })
-
-    test('collab_agent_spawn_end returns system-message with status', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('collab_agent_spawn_end', {
-        call_id: 'cs-1',
-        new_thread_id: 'new-1',
-        status: 'running',
-        prompt: '',
-        sender_thread_id: 'sender-1',
-      }))
-      expect(r!.content).toBe('Agent spawned: running')
-      expect(r!.metadata?.newThreadId).toBe('new-1')
-    })
-
-    test('collab_agent_interaction_begin returns system-message', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('collab_agent_interaction_begin', {
-        call_id: 'ci-1',
-        prompt: 'Check status',
-      }))
-      expect(r!.content).toContain('Check status')
-    })
-
-    test('collab_waiting_begin shows count', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('collab_waiting_begin', {
-        call_id: 'cw-1',
-        receiver_thread_ids: ['t1', 't2', 't3'],
-      }))
-      expect(r!.content).toBe('Waiting for 3 agent(s)')
+    test('item/completed plan returns assistant-message', () => {
+      const entry = normalize('item/completed', {
+        item: { type: 'plan', id: 'p-1', text: 'Full plan text' },
+      })
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('assistant-message')
+      expect(entry!.content).toBe('Full plan text')
+      expect(entry!.metadata?.isPlan).toBe(true)
     })
   })
 
   // ------------------------------------------------------------------
-  // Elicitation request
+  // 14. Review mode and context compaction
   // ------------------------------------------------------------------
-  describe('elicitation_request', () => {
-    test('returns system-message with server name', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('elicitation_request', {
-        server_name: 'github',
-        message: 'Please authenticate',
-        id: 'el-1',
-      }))
-      expect(r!.entryType).toBe('system-message')
-      expect(r!.content).toBe('Please authenticate')
-      expect(r!.metadata?.serverName).toBe('github')
+  describe('review mode and compaction', () => {
+    test('item/completed enteredReviewMode returns system-message', () => {
+      const entry = normalize('item/completed', {
+        item: { type: 'enteredReviewMode', id: 'r-1', review: 'Review changes' },
+      })
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('system-message')
+      expect(entry!.content).toBe('Review changes')
+    })
+
+    test('item/completed exitedReviewMode returns system-message', () => {
+      const entry = normalize('item/completed', {
+        item: { type: 'exitedReviewMode', id: 'r-2', review: '' },
+      })
+      expect(entry).not.toBeNull()
+      expect(entry!.content).toBe('Exited review mode')
+    })
+
+    test('item/completed contextCompaction returns system-message', () => {
+      const entry = normalize('item/completed', {
+        item: { type: 'contextCompaction', id: 'cc-1' },
+      })
+      expect(entry).not.toBeNull()
+      expect(entry!.content).toBe('Context compacted')
+    })
+
+    test('thread/compacted returns system-message', () => {
+      const entry = normalize('thread/compacted', {})
+      expect(entry).not.toBeNull()
+      expect(entry!.content).toBe('Context compacted')
     })
   })
 
   // ------------------------------------------------------------------
-  // web_search_end enriched
+  // 15. Model rerouted
   // ------------------------------------------------------------------
-  describe('web_search_end enriched', () => {
-    test('includes action type', () => {
-      const n = new CodexLogNormalizer()
-      const r = parseSingle(n, codexEvent('web_search_end', {
-        call_id: 'ws-1',
-        query: 'how to fix TypeScript errors',
-        action: { type: 'search' },
-      }))
-      expect(r!.metadata?.actionType).toBe('search')
+  describe('model/rerouted', () => {
+    test('returns system-message with model names', () => {
+      const entry = normalize('model/rerouted', { fromModel: 'o3', toModel: 'o4-mini' })
+      expect(entry).not.toBeNull()
+      expect(entry!.entryType).toBe('system-message')
+      expect(entry!.content).toBe('Model rerouted from o3 to o4-mini')
     })
   })
 })


### PR DESCRIPTION
## Summary

- Fix codex normalizer to handle the actual app-server v2 JSON-RPC notifications instead of the `codex/event/*` format (which only exists in mcp-server mode and was never received)
- This was causing **assistant messages, reasoning/thinking, and most tool types to be silently dropped**
- Add full ThreadItem type coverage: mcpToolCall, dynamicToolCall, webSearch, collabAgentToolCall, plan, imageView, imageGeneration, reviewMode, contextCompaction
- Add missing notification methods: `item/plan/delta`, `model/rerouted`, `thread/compacted`, `thread/tokenUsage/updated`
- Remove ~1770 lines of dead code (`codex/event/*` handler + tests)

## What was broken

| Notification | Before | After |
|---|---|---|
| `item/agentMessage/delta` | Skipped (returned null) | Streaming assistant-message |
| `item/completed` agentMessage | Skipped (returned null) | Final assistant-message |
| `item/reasoning/textDelta` | Skipped (returned null) | Streaming thinking |
| `item/reasoning/summaryTextDelta` | Skipped (returned null) | Streaming thinking |
| `item/completed` reasoning | Skipped (returned null) | Final thinking entry |
| `item/started` mcpToolCall | Not handled | tool-use entry |
| `item/completed` mcpToolCall | Not handled | tool-use result |
| `item/started` webSearch | Not handled | tool-use entry |
| `item/started` dynamicToolCall | Not handled | tool-use entry |
| `turn/started` / `turn/completed` | Gated behind never-set flag | Always handled |

## Test plan

- [x] All 493 API tests pass (0 fail)
- [x] Normalizer tests: 48 pass covering all v2 ThreadItem types
- [x] ESLint clean
- [ ] Manual verification with live Codex agent