### PR TITLE
fix: add toolCallId to codex streaming output deltas

### DIFF
--- a/apps/api/src/engines/executors/codex/normalizer.ts
+++ b/apps/api/src/engines/executors/codex/normalizer.ts
@@ -637,11 +637,17 @@ export class CodexLogNormalizer {
     const params = (data.params ?? {}) as Record<string, unknown>
     const delta = params.delta as string | undefined
     if (!delta) return null
+    const itemId = params.itemId as string | undefined
     return {
       entryType: 'tool-use',
       content: delta,
       timestamp: now,
-      metadata: { isResult: true, streaming: true },
+      metadata: {
+        toolName: 'Bash',
+        isResult: true,
+        streaming: true,
+        ...(itemId && { toolCallId: itemId }),
+      },
     }
   }
 
@@ -652,11 +658,17 @@ export class CodexLogNormalizer {
     const params = (data.params ?? {}) as Record<string, unknown>
     const delta = params.delta as string | undefined
     if (!delta) return null
+    const itemId = params.itemId as string | undefined
     return {
       entryType: 'tool-use',
       content: delta,
       timestamp: now,
-      metadata: { isResult: true, streaming: true },
+      metadata: {
+        toolName: 'Edit',
+        isResult: true,
+        streaming: true,
+        ...(itemId && { toolCallId: itemId }),
+      },
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix tool message grouping for Codex engine by adding `toolCallId` (extracted from `itemId` in v2 protocol) to `commandExecution/outputDelta` and `fileChange/outputDelta` streaming entries
- Without this, each streaming delta was treated as an unpaired result in the frontend `use-chat-messages` hook, causing every delta to flush the tool buffer and break tool group aggregation

## Root cause

The v2 protocol sends `{ method: "item/commandExecution/outputDelta", params: { threadId, turnId, itemId, delta } }` but the normalizer was discarding `itemId`. The frontend uses `toolCallId` to pair action entries with their results — missing `toolCallId` means "unpaired" → immediate flush → broken grouping.

## Test plan

- [x] 493 API tests pass
- [x] ESLint clean
- [ ] Manual verification: Codex tool calls should group action + streaming output + result into a single collapsible tool group